### PR TITLE
Change energy unit to Wh and add voltage/current attributes to power sensor.

### DIFF
--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -47,7 +47,7 @@ SENSOR_TYPES = {
     },
     "total_power": {
         "key": "state.totalPower",
-        "attrs": ["state.latestPulse"],
+        "attrs": ["state.latestPulse", "state.inCurrentT2", "state.inCurrentT3", "state.inCurrentT4", "state.inCurrentT5", "state.inVoltageT1T2", "state.inVoltageT1T3", "state.inVoltageT1T4", "state.inVoltageT1T5", "state.inVoltageT2T3", "state.inVoltageT2T4", "state.inVoltageT2T5", "state.inVoltageT3T4", "state.inVoltageT3T5", "state.inVoltageT4T5"],
         "units": "W",
         "convert_units_func": watts_to_kilowatts,
         "icon": "mdi:flash",
@@ -55,14 +55,14 @@ SENSOR_TYPES = {
     "session_energy": {
         "key": "state.sessionEnergy",
         "attrs": [],
-        "units": "W",
+        "units": "Wh",
         "convert_units_func": round_2_dec,
         "icon": "mdi:flash",
     },
     "energy_per_hour": {
         "key": "state.energyPerHour",
         "attrs": [],
-        "units": "W",
+        "units": "Wh",
         "convert_units_func": round_2_dec,
         "icon": "mdi:flash",
     },

--- a/links.sh
+++ b/links.sh
@@ -1,6 +1,5 @@
 ln -s custom_components/easee/__init__.py .
 ln -s custom_components/easee/manifest.json .
 ln -s custom_components/easee/sensor.py .
-ln -s custom_components/easee/easee.py .
 ln -s custom_components/easee/services.py .
 ln -s custom_components/easee/services.yaml .


### PR DESCRIPTION
The units for the energy sensors are changed to Wh (since that is the unit for energy, not W as was previously used, which is a unit for power).

The power sensor now has attributes where currents and voltages are visible.

Background information:
Seems like the nomenclature used by easee API is:
T1 = terminal 1, normally connected to PE (protective ground).
T2 = terminal 2, can either be connected to N (neutral) or L1 (phase 1) depending on what type of electric system it is connected to.
T3 = terminal 3, L1 or L2 depending on electric system.
T4 = terminal 4, L2, L3 or nothing depending on electric system.
T5 = terminal 5, L3 or nothing depending on electric system.
So on a 3-phase system as in Sweden, T1 = PE, T2 = N, T3 = L1, T4 = L2, T5 = L3.

Which means inCurrentT2 will be the current on N, inCurrentT3 will be current on L1, inCurrentT4 will be current on L2, InCurrentT5 will be current on L3. Depending on what type of car is charged currents can occur on all of these in various ways. I.e. a 1-phase car will load on L1 and have the corresponding current on N as well, a true 3-phase car will load on L1, L2, L3 but not at all on N.

And inVoltageT1T2 is the voltage between terminal 1 and 2 (PE and N which is always 0 or close to 0 in a Swedish electric system) and so on.
Which means that the interesting voltages in a Swedish 3-phase electric system will be: inVoltageT2T3 (L1 voltage ~230V), inVoltageT2T4 (L2 voltage ~230V), inVoltageT2T5 (L3 voltage ~230V) and possibly inVoltageT3T4 (L1 to L2 voltage ~400V), inVoltageT3T5 (L1 to L3 voltage ~400V), inVoltageT4T5 (L2 to L3 voltage ~400V).

In other versions of electrical some of the other attributes are more interesting, so all of them should be included.
So even it this may be a bit confusing to the layperson, I think there is a value in at least having them accessible.
