### PR TITLE
Fixing circuit current returning null

### DIFF
--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -147,9 +147,15 @@ SENSOR_TYPES = {
         "icon": "mdi:sine-wave",
         "state_func": lambda state: float(
             max(
-                state["circuitTotalPhaseConductorCurrentL1"],
-                state["circuitTotalPhaseConductorCurrentL2"],
-                state["circuitTotalPhaseConductorCurrentL3"],
+                state["circuitTotalPhaseConductorCurrentL1"]
+                if state["circuitTotalPhaseConductorCurrentL1"] is not None
+                else 0.0,
+                state["circuitTotalPhaseConductorCurrentL2"]
+                if state["circuitTotalPhaseConductorCurrentL2"] is not None
+                else 0.0,
+                state["circuitTotalPhaseConductorCurrentL3"]
+                if state["circuitTotalPhaseConductorCurrentL3"] is not None
+                else 0.0,
             )
         ),
     },


### PR DESCRIPTION
Seems like Easee API returns null at some point for the circuitTotalPhaseConductorCurrentL1/L2/L3 which leads to exceptions due to the max() and round_2_dec() functions used in our setup. Didn't get this in the start, but appears repeatedly in my logs now. The null value successfully becomes None, so implemented a check to set 0.0 if state is None.