### PR TITLE
fix cable locked sensor

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -22,6 +22,8 @@ EASEE_ENTITIES = {
         "units": None,
         "convert_units_func": None,
         "icon": "mdi:lock",
+        "state_func": lambda state: state["lockCablePermanently"]
+        or state["cableLocked"],
         "switch_func": "lockCablePermanently",
     },
     "status": {


### PR DESCRIPTION
For some reason Easee doesn't show cableLocked when lockCablePermanently is on (and thus locked). So adding an or to the state condition to make sure HA shows locked if it is either locked or permanently locked.