### PR TITLE
Charger name

### DIFF
--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -98,7 +98,7 @@ class ChargerEntity(Entity):
     @property
     def name(self):
         """Return the name of the entity."""
-        return f"{DOMAIN}_charger_{self.charger_data.charger.id}_{self._entity_name}"
+        return f"{DOMAIN}_charger_{self.charger_data.charger.name}_{self._entity_name}"
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -87,7 +87,7 @@ class ChargerConsumptionSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DOMAIN}_charger_{self.charger.id}_{self._sensor_name}"
+        return f"{DOMAIN}_charger_{self.charger.name}_{self._sensor_name}"
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
For discussion:

Change from charger.id to charger.name for entity names.  From my point of view, I'd prefer not to share my id for instance when sharing screenshots and similar.

What do you guys think @fondberg @olalid ?