### PR TITLE
Bugfix units consumption sensors

### DIFF
--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -60,11 +60,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 )
 
         monitored_days = config.options.get(MEASURED_CONSUMPTION_DAYS, [])
-        consumption_unit = (
-            CUSTOM_UNITS_TABLE[data["units"]]
-            if data["units"] in custom_units
-            else data["units"]
-        )
+        consumption_unit = CUSTOM_UNITS_TABLE["kWh"] if "kWh" in custom_units else "kWh"
         for interval in monitored_days:
             _LOGGER.info("Will measure days: %s", interval)
             entities.append(


### PR DESCRIPTION
Bummer. The units for consumption sensors suddenly became Amps (or last data["unit"] from last for-loop). Hardcoding as kWh as default when checking for custom units.