### PR TITLE
Split locked cable and permanently locked cable

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -31,15 +31,20 @@ EASEE_ENTITIES = {
         "icon": "mdi:auto-fix",
         "switch_func": "smart_charging",
     },
-    "cableLocked": {
+    "cableLockedCar": {
+        "key": "state.cableLocked",
+        "attrs": ["state.lockCablePermanently", "state.cableLocked",],
+        "units": None,
+        "convert_units_func": None,
+        "icon": "mdi:lock",
+    },
+    "cablePermanentlyLockedCharger  ": {
         "type": "switch",
         "key": "state.lockCablePermanently",
         "attrs": ["state.lockCablePermanently", "state.cableLocked",],
         "units": None,
         "convert_units_func": None,
         "icon": "mdi:lock",
-        "state_func": lambda state: state["lockCablePermanently"]
-        or state["cableLocked"],
         "switch_func": "lockCablePermanently",
     },
     "status": {


### PR DESCRIPTION
Split into cableLockedCar (sensor) and cablePermanentlyLockedCharger (switch).

In my experience, the cableLocked refers to and is decided by the car, while the cablePermanentlyLocked refers to and is decided by the charger. Splitting into to entities, one sensor (we cannot use switch for what the car decides) and one switch (wheter the cable is permanetly locked to charger or not, as per Easee app).
