### PR TITLE
Fixed error when config contains sensor names that have been removed

### DIFF
--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -31,34 +31,35 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for charger_data in chargers_data._chargers:
         for key in monitored_conditions:
-            data = EASEE_ENTITIES[key]
-            entity_type = data.get("type", "sensor")
+            if key in EASEE_ENTITIES:
+                data = EASEE_ENTITIES[key]
+                entity_type = data.get("type", "sensor")
 
-            if entity_type == "sensor":
-                _LOGGER.debug(
-                    "Adding entity: %s (%s) for charger %s",
-                    key,
-                    entity_type,
-                    charger_data.charger.name,
-                )
-
-                if data["units"] in custom_units:
-                    data["units"] = CUSTOM_UNITS_TABLE[data["units"]]
-
-                entities.append(
-                    ChargerSensor(
-                        charger_data=charger_data,
-                        name=key,
-                        state_key=data["key"],
-                        units=data["units"],
-                        convert_units_func=convert_units_funcs.get(
-                            data["convert_units_func"], None
-                        ),
-                        attrs_keys=data["attrs"],
-                        icon=data["icon"],
-                        state_func=data.get("state_func", None),
+                if entity_type == "sensor":
+                    _LOGGER.debug(
+                        "Adding entity: %s (%s) for charger %s",
+                        key,
+                        entity_type,
+                        charger_data.charger.name,
                     )
-                )
+
+                    if data["units"] in custom_units:
+                        data["units"] = CUSTOM_UNITS_TABLE[data["units"]]
+
+                        entities.append(
+                            ChargerSensor(
+                                charger_data=charger_data,
+                                name=key,
+                                state_key=data["key"],
+                                units=data["units"],
+                                convert_units_func=convert_units_funcs.get(
+                                    data["convert_units_func"], None
+                                ),
+                                attrs_keys=data["attrs"],
+                                icon=data["icon"],
+                                state_func=data.get("state_func", None),
+                            )
+                        )
 
         monitored_days = config.options.get(MEASURED_CONSUMPTION_DAYS, [])
         consumption_unit = (

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -18,31 +18,32 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for charger_data in chargers_data._chargers:
         for key in monitored_conditions:
-            data = EASEE_ENTITIES[key]
-            entity_type = data.get("type", "sensor")
+            if key in EASEE_ENTITIES:
+                data = EASEE_ENTITIES[key]
+                entity_type = data.get("type", "sensor")
 
-            if entity_type == "switch":
-                _LOGGER.debug(
-                    "Adding entity: %s (%s) for charger %s",
-                    key,
-                    entity_type,
-                    charger_data.charger.name,
-                )
-                entities.append(
-                    ChargerSwitch(
-                        charger_data=charger_data,
-                        name=key,
-                        state_key=data["key"],
-                        units=data["units"],
-                        convert_units_func=convert_units_funcs.get(
-                            data["convert_units_func"], None
-                        ),
-                        attrs_keys=data["attrs"],
-                        icon=data["icon"],
-                        state_func=data.get("state_func", None),
-                        switch_func=data.get("switch_func", None),
+                if entity_type == "switch":
+                    _LOGGER.debug(
+                        "Adding entity: %s (%s) for charger %s",
+                        key,
+                        entity_type,
+                        charger_data.charger.name,
                     )
-                )
+                    entities.append(
+                        ChargerSwitch(
+                            charger_data=charger_data,
+                            name=key,
+                            state_key=data["key"],
+                            units=data["units"],
+                            convert_units_func=convert_units_funcs.get(
+                                data["convert_units_func"], None
+                            ),
+                            attrs_keys=data["attrs"],
+                            icon=data["icon"],
+                            state_func=data.get("state_func", None),
+                            switch_func=data.get("switch_func", None),
+                        )
+                    )
 
     chargers_data._entities.extend(entities)
     async_add_entities(entities)


### PR DESCRIPTION
If you have a config that contains sensor or switch names that have been removed in a later revision than the one used to set the config, the code will try to index with a non-existent key in EASEE_ENTITIES.
This PR adds a check to make sure the key exists before trying to index with it.
