### PR TITLE
Add config.authorizationRequired

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -87,6 +87,7 @@ EASEE_ENTITIES = {
             "state.outputPhase",
             "state.ledMode",
             "state.cableRating",
+            "config.authorizationRequired",
             "config.limitToSinglePhaseCharging",
             "config.localNodeType",
             "config.localAuthorizationRequired",


### PR DESCRIPTION
as this is set to true if the has been locked to rfid using the app or the set_access service.

This way we can check if the chargerbot is really paused or it its paused waiting for auth.