### PR TITLE
Add Lifetime Energy Consumption Sensor

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -120,6 +120,14 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_ENERGY,
         "icon": None,
     },
+    "lifetime_energy": {
+        "key": "state.lifetimeEnergy",
+        "attrs": [],
+        "units": ENERGY_KILO_WATT_HOUR,
+        "convert_units_func": "round_1_dec",
+        "device_class": DEVICE_CLASS_ENERGY,
+        "icon": "mdi:counter",
+    },
     "energy_per_hour": {
         "key": "state.energyPerHour",
         "attrs": [],

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -124,7 +124,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "key": "state.lifetimeEnergy",
         "attrs": [],
         "units": ENERGY_KILO_WATT_HOUR,
-        "convert_units_func": "round_1_dec",
+        "convert_units_func": None,
         "device_class": DEVICE_CLASS_ENERGY,
         "icon": "mdi:counter",
     },


### PR DESCRIPTION
This small tweak creates an optional sensor that reads the "lifetimeEnergy" attribute from the chargerstate. This is useful for someone that wants to track costs via the HASS Utility Meter and Template Sensors as this value does not reset and only counts up.