### PR TITLE
Keep track of online status of charger/equalizer and/or cloud

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -85,6 +85,7 @@ class EqualizerData:
 
     def update_stream_data(self, data_type, data_id, value):
         self.state["latestPulse"] = datetime.utcnow()
+        self.state["isOnline"] = ONLINE
         try:
             name = EqualizerStreamData(data_id).name
         except ValueError:
@@ -134,6 +135,7 @@ class ChargerData:
 
     def update_stream_data(self, data_type, data_id, value):
         self.state["latestPulse"] = datetime.utcnow()
+        self.state["isOnline"] = True
         try:
             name = ChargerStreamData(data_id).name
         except ValueError:
@@ -346,8 +348,6 @@ class Controller:
                 )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
                     charger_data.state["isOnline"] = False
-                else:
-                    charger_data.state["isOnline"] = True
 
         if self._first_site_poll or not self.easee.sr_is_connected():
             self._first_site_poll = False
@@ -385,8 +385,6 @@ class Controller:
                 )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
                     equalizer_data.state["isOnline"] = OFFLINE
-                else:
-                    equalizer_data.state["isOnline"] = ONLINE
 
         if self._first_equalizer_poll or not self.easee.sr_is_connected():
             self._first_equalizer_poll = False

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -340,7 +340,10 @@ class Controller:
 
         if not self._first_site_poll:
             for charger_data in self.chargers_data:
-                elapsed = charger_data.state["latestPulse"] - datetime.utcnow()
+                elapsed = datetime.utcnow() - charger_data.state["latestPulse"]
+                _LOGGER.debug(
+                    f"Seconds since {charger_data.charger.id} lastPulse {elapsed.total_seconds()}"
+                )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
                     charger_data.state["isOnline"] = False
                 else:
@@ -376,7 +379,10 @@ class Controller:
         """ gets equalizer state for all equalizers """
         if not self._first_equalizer_poll:
             for equalizer_data in self.equalizers_data:
-                elapsed = equalizer_data.state["latestPulse"] - datetime.utcnow()
+                elapsed = datetime.utcnow() - equalizer_data.state["latestPulse"]
+                _LOGGER.debug(
+                    f"Seconds since {equalizer_data.equalizer.id} lastPulse {elapsed.total_seconds()}"
+                )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
                     equalizer_data.state["isOnline"] = OFFLINE
                 else:


### PR DESCRIPTION
A patch that aims to keep track of when a charger/equalizer goes offline/online and/or if the cloud API does not respond.