### PR TITLE
Validation with hassfest

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master

--- a/INFO.md
+++ b/INFO.md
@@ -1,4 +1,4 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2020.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 

--- a/INFO.md
+++ b/INFO.md
@@ -1,4 +1,4 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 __VERSION__ = "0.9.26"
 
 bump:
-	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/easee/const.py
+	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/easee/const.py custom_component/easee/manifest.json
 
 lint:
 	isort custom_components

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 __VERSION__ = "0.9.26"
 
 bump:
-	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/easee/const.py custom_component/easee/manifest.json
+	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/easee/const.py custom_components/easee/manifest.json
 
 lint:
 	isort custom_components

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2020.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -54,7 +54,7 @@ MANDATORY_EASEE_ENTITIES = {
         ],
         "units": None,
         "convert_units_func": "map_charger_status",
-        "device_class": "easee_status",
+        "device_class": "easee__status",
         "icon": "mdi:ev-station",
     },
 }
@@ -295,7 +295,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "attrs": [],
         "units": "",
         "convert_units_func": "map_reason_no_current",
-        "device_class": "reason_no_current",
+        "device_class": "easee__reason_no_current",
         "icon": "mdi:alert-circle",
     },
     "is_enabled": {
@@ -377,7 +377,7 @@ EASEE_EQ_ENTITIES = {
         ],
         "units": None,
         "convert_units_func": None,
-        "device_class": "easee_eq_status",
+        "device_class": "easee__eq_status",
         "icon": "mdi:server-network",
     },
     "power": {

--- a/custom_components/easee/manifest.json
+++ b/custom_components/easee/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "easee",
   "name": "Easee EV charger",
+  "version": "0.9.26",
   "documentation": "https://github.com/fondberg/easee_hass",
   "issue_tracker": "https://github.com/fondberg/easee_hass/issues",
   "requirements": [

--- a/custom_components/easee/translations/sensor.en.json
+++ b/custom_components/easee/translations/sensor.en.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "easee_status": {
+    "easee__status": {
       "disconnected": "Disconnected",
       "awaiting_start": "Awaiting start",
       "charging": "Charging",
@@ -8,11 +8,11 @@
       "completed": "Completed",
       "ready_to_charge": "Ready to charge"
     },
-    "easee_eq_status": {
+    "easee__eq_status": {
       "online": "Online",
       "offline": "Offline"
     },
-    "reason_no_current": {
+    "easee__reason_no_current": {
       "none": "None",
       "ok": "OK",
       "max_circuit_current_too_low": "Max circuit current too low",

--- a/custom_components/easee/translations/sensor.en.json
+++ b/custom_components/easee/translations/sensor.en.json
@@ -1,7 +1,7 @@
 {
   "state": {
     "easee__status": {
-      "disconnected": "Disconnected",
+      "disconnected": "Car disconnected",
       "awaiting_start": "Awaiting start",
       "charging": "Charging",
       "error": "Error",

--- a/custom_components/easee/translations/sensor.nb.json
+++ b/custom_components/easee/translations/sensor.nb.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "easee_status": {
+    "easee__status": {
       "disconnected": "Frakoblet",
       "awaiting_start": "Avventer start",
       "charging": "Lader",
@@ -8,11 +8,11 @@
       "completed": "Fullført",
       "ready_to_charge": "Klar til lading"
     },
-    "easee_eq_status": {
+    "easee__eq_status": {
       "online": "Online",
       "offline": "Offline"
     },
-    "reason_no_current": {
+    "easee__reason_no_current": {
       "none": "Ingen",
       "ok": "OK",
       "max_circuit_current_too_low": "Max circuit current er for lav",

--- a/custom_components/easee/translations/sensor.nb.json
+++ b/custom_components/easee/translations/sensor.nb.json
@@ -1,7 +1,7 @@
 {
   "state": {
     "easee__status": {
-      "disconnected": "Frakoblet",
+      "disconnected": "Bil frakoblet",
       "awaiting_start": "Avventer start",
       "charging": "Lader",
       "error": "Feil",

--- a/custom_components/easee/translations/sensor.sv.json
+++ b/custom_components/easee/translations/sensor.sv.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "easee_status": {
+    "easee__status": {
       "disconnected": "Ej ansluten",
       "awaiting_start": "Väntar på start",
       "charging": "Laddar",
@@ -8,11 +8,11 @@
       "completed": "Klar",
       "ready_to_charge": "Redo för laddning"
     },
-    "easee_eq_status": {
+    "easee__eq_status": {
       "online": "Ansluten",
       "offline": "Ej ansluten"
     },
-    "reason_no_current": {
+    "easee__reason_no_current": {
       "none": "Ingen",
       "ok": "OK",
       "max_circuit_current_too_low": "Max kretsström för låg",

--- a/custom_components/easee/translations/sensor.sv.json
+++ b/custom_components/easee/translations/sensor.sv.json
@@ -1,7 +1,7 @@
 {
   "state": {
     "easee__status": {
-      "disconnected": "Ej ansluten",
+      "disconnected": "Bil ej ansluten",
       "awaiting_start": "Väntar på start",
       "charging": "Laddar",
       "error": "Fel",


### PR DESCRIPTION
Added github action to validate custom_component with hassfest.
Fixed warnings that hassfest revealed:
- Add version string to manifest.json - soon to be mandatory
- Update makefile/bumpversion
- Fix names of custom device_classes

https://developers.home-assistant.io/blog/2020/04/16/hassfest
https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/