### PR TITLE
Binary sensor for equalizer, cleanup

### DIFF
--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -48,7 +48,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         LISTENER_FN_CLOSE: undo_listener,
     }
 
-    await controller.add_schedulers()
     return True
 
 

--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -24,8 +24,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN] = {}
     hass.data[DOMAIN]["entities"] = []
     hass.data[DOMAIN]["entities_to_remove"] = []
+    hass.data[DOMAIN]["eq_entities_to_remove"] = []
     hass.data[DOMAIN]["sites_to_remove"] = []
-    hass.data[DOMAIN]["days_to_remove"] = []
     _LOGGER.debug("Setting up Easee component version %s", VERSION)
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)

--- a/custom_components/easee/binary_sensor.py
+++ b/custom_components/easee/binary_sensor.py
@@ -15,6 +15,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     controller = hass.data[DOMAIN]["controller"]
     entities = controller.get_binary_sensor_entities()
     async_add_entities(entities)
+    controller.setup_done("binary_sensor")
 
 
 class ChargerBinarySensor(ChargerEntity, BinarySensorEntity):

--- a/custom_components/easee/binary_sensor.py
+++ b/custom_components/easee/binary_sensor.py
@@ -25,3 +25,13 @@ class ChargerBinarySensor(ChargerEntity, BinarySensorEntity):
         """Return true if the binary sensor is on."""
         _LOGGER.debug("Getting state of %s" % self._entity_name)
         return self._state
+
+
+class EqualizerBinarySensor(ChargerEntity, BinarySensorEntity):
+    """Easee charger binary sensor class."""
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        _LOGGER.debug("Getting state of %s" % self._entity_name)
+        return self._state

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -130,7 +130,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_MONITORED_EQ_CONDITIONS,
                         default=self.config_entry.options.get(
-                            CONF_MONITORED_EQ_CONDITIONS, ["status"]
+                            CONF_MONITORED_EQ_CONDITIONS, ["online"]
                         ),
                     ): cv.multi_select(sensor_eq_multi_select),
                     vol.Optional(
@@ -162,5 +162,4 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             for cond in self.prev_options.get(CONF_MONITORED_SITES, {})
             if cond not in self.options[CONF_MONITORED_SITES]
         ]
-        _LOGGER.debug("Days_to_remove: %s", self.hass.data[DOMAIN]["days_to_remove"])
         return self.async_create_entry(title="", data=self.options)

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -364,8 +364,8 @@ OPTIONAL_EASEE_ENTITIES = {
 }
 
 EASEE_EQ_ENTITIES = {
-    "status": {
-        "type": "eq_sensor",
+    "online": {
+        "type": "eq_binary_sensor",
         "key": "state.isOnline",
         "attrs": [
             "state.latestPulse",
@@ -377,8 +377,8 @@ EASEE_EQ_ENTITIES = {
         ],
         "units": None,
         "convert_units_func": None,
-        "device_class": "easee__eq_status",
-        "icon": "mdi:server-network",
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "icon": None,
     },
     "power": {
         "type": "eq_sensor",
@@ -456,9 +456,6 @@ EASEE_EQ_ENTITIES = {
         "icon": None,
     },
 }
-
-ONLINE = "online"
-OFFLINE = "offline"
 
 EA_DISCONNECTED = "disconnected"
 EA_AWAITING_START = "awaiting_start"

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -259,6 +259,9 @@ class Controller:
         self._first_site_poll = True
         self._first_equalizer_poll = True
         self._first_schedule_poll = True
+        self._init_count = 0
+        self.running_loop = asyncio.get_running_loop()
+        self.event_loop = asyncio.get_event_loop()
 
         self._create_entitites()
 
@@ -276,6 +279,13 @@ class Controller:
                     _LOGGER.debug("Scheduling equalizer update")
                     self.update_equalizers_state()
                     return
+
+    def setup_done(self, name):
+        _LOGGER.debug(f"Entities {name} setup done")
+        self._init_count = self._init_count + 1
+
+        if self._init_count == 3 and self.running_loop is not None:
+            asyncio.run_coroutine_threadsafe(self.add_schedulers(), self.event_loop)
 
     def update_ha_state(self):
         # Schedule an update for all other included entities

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -32,7 +32,7 @@ from pyeasee.exceptions import (
     TooManyRequestsException,
 )
 
-from .binary_sensor import ChargerBinarySensor
+from .binary_sensor import ChargerBinarySensor, EqualizerBinarySensor
 from .const import (
     CONF_MONITORED_EQ_CONDITIONS,
     CONF_MONITORED_SITES,
@@ -40,8 +40,6 @@ from .const import (
     CUSTOM_UNITS_TABLE,
     EASEE_EQ_ENTITIES,
     MANDATORY_EASEE_ENTITIES,
-    OFFLINE,
-    ONLINE,
     OPTIONAL_EASEE_ENTITIES,
     TIMEOUT,
 )
@@ -78,14 +76,16 @@ class EqualizerData:
 
     def __init__(self, equalizer: Equalizer, site: Site):
         """Initialize the charger data."""
-        self.equalizer: Equalizer = equalizer
+        self.product: Equalizer = equalizer
         self.site: Site = site
         self.state = []
         self.config = []
 
     def update_stream_data(self, data_type, data_id, value):
-        self.state["latestPulse"] = datetime.utcnow()
-        self.state["isOnline"] = ONLINE
+        now = datetime.utcnow().replace(microsecond=0)
+        self.state["latestPulse"] = now
+        _LOGGER.debug(f"Equalizer latestPulse update {now}")
+        self.state["isOnline"] = True
         try:
             name = EqualizerStreamData(data_id).name
         except ValueError:
@@ -116,7 +116,7 @@ class ChargerData:
 
     def __init__(self, charger: Charger, circuit: Circuit, site: Site):
         """Initialize the charger data."""
-        self.charger: Charger = charger
+        self.product: Charger = charger
         self.circuit: Circuit = circuit
         self.site: Site = site
         self.state: List[ChargerState] = []
@@ -125,7 +125,7 @@ class ChargerData:
 
     async def schedules_async_refresh(self):
         try:
-            self.schedule = await self.charger.get_basic_charge_plan()
+            self.schedule = await self.product.get_basic_charge_plan()
         except (TooManyRequestsException, ServerFailureException):
             _LOGGER.debug("Got server error while fetching schedule")
         except NotFoundException:
@@ -134,7 +134,9 @@ class ChargerData:
         _LOGGER.debug("Schedule: %s", self.schedule)
 
     def update_stream_data(self, data_type, data_id, value):
-        self.state["latestPulse"] = datetime.utcnow()
+        now = datetime.utcnow().replace(microsecond=0)
+        self.state["latestPulse"] = now
+        _LOGGER.debug(f"Charger latestPulse update {now}")
         self.state["isOnline"] = True
         try:
             name = ChargerStreamData(data_id).name
@@ -199,6 +201,7 @@ class Controller:
         self.switch_entities = []
         self.sensor_entities = []
         self.equalizer_sensor_entities = []
+        self.equalizer_binary_sensor_entities = []
 
     async def initialize(self):
         """ initialize the session and get initial data """
@@ -227,17 +230,17 @@ class Controller:
         self.sites: List[Site] = await self.easee.get_sites()
 
         self.monitored_sites = self.config.options.get(
-            CONF_MONITORED_SITES, [site["name"] for site in self.sites]
+            CONF_MONITORED_SITES, [site.name for site in self.sites]
         )
 
         for site in self.sites:
-            if not site["name"] in self.monitored_sites:
-                _LOGGER.debug("Found site (unmonitored): %s %s", site.id, site["name"])
+            if site.name not in self.monitored_sites:
+                _LOGGER.debug("Found site (unmonitored): %s %s", site.id, site.name)
             else:
-                _LOGGER.debug("Found site (monitored): %s %s", site.id, site["name"])
+                _LOGGER.debug("Found site (monitored): %s %s", site.id, site.name)
                 for equalizer in site.get_equalizers():
                     _LOGGER.debug(
-                        "Found equalizer: %s %s", equalizer.id, equalizer["name"]
+                        "Found equalizer: %s %s", equalizer.id, equalizer.name
                     )
                     self.equalizers.append(equalizer)
                     equalizer_data = EqualizerData(equalizer, site)
@@ -261,14 +264,14 @@ class Controller:
 
     async def stream_callback(self, id, data_type, data_id, value):
         for charger_data in self.chargers_data:
-            if charger_data.charger.id == id:
+            if charger_data.product.id == id:
                 if charger_data.update_stream_data(data_type, data_id, value):
                     _LOGGER.debug("Scheduling charger update")
                     self.update_ha_state()
                     return
 
         for equalizer_data in self.equalizers_data:
-            if equalizer_data.equalizer.id == id:
+            if equalizer_data.product.id == id:
                 if equalizer_data.update_stream_data(data_type, data_id, value):
                     _LOGGER.debug("Scheduling equalizer update")
                     self.update_equalizers_state()
@@ -285,7 +288,10 @@ class Controller:
 
     def update_equalizers_state(self):
         # Schedule an update for all equalizer entities
-        for entity in self.equalizer_sensor_entities:
+        all_entities = (
+            self.equalizer_sensor_entities + self.equalizer_binary_sensor_entities
+        )
+        for entity in all_entities:
             entity.async_schedule_update_ha_state(True)
 
     async def add_schedulers(self):
@@ -344,7 +350,7 @@ class Controller:
             for charger_data in self.chargers_data:
                 elapsed = datetime.utcnow() - charger_data.state["latestPulse"]
                 _LOGGER.debug(
-                    f"Seconds since {charger_data.charger.id} lastPulse {elapsed.total_seconds()}"
+                    f"Seconds since {charger_data.product.id} latestPulse {elapsed.total_seconds()}"
                 )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
                     charger_data.state["isOnline"] = False
@@ -353,7 +359,7 @@ class Controller:
             self._first_site_poll = False
 
             for site in self.get_sites():
-                if site["name"] in self.monitored_sites:
+                if site.name in self.monitored_sites:
                     _LOGGER.debug("Getting state for site %s", site.id)
                     sites_state[site.id] = await self.easee.get_site_state(site.id)
 
@@ -364,7 +370,7 @@ class Controller:
                         charger_data.state.id,
                     )
                     continue
-                charger_id = charger_data.charger.id
+                charger_id = charger_data.product.id
                 site_state = sites_state[charger_data.site.id]
 
                 charger_data.state = site_state.get_charger_state(charger_id, raw=True)
@@ -381,19 +387,15 @@ class Controller:
             for equalizer_data in self.equalizers_data:
                 elapsed = datetime.utcnow() - equalizer_data.state["latestPulse"]
                 _LOGGER.debug(
-                    f"Seconds since {equalizer_data.equalizer.id} lastPulse {elapsed.total_seconds()}"
+                    f"Seconds since {equalizer_data.product.id} latestPulse {elapsed.total_seconds()}"
                 )
                 if elapsed.total_seconds() > OFFLINE_DELAY:
-                    equalizer_data.state["isOnline"] = OFFLINE
+                    equalizer_data.state["isOnline"] = False
 
         if self._first_equalizer_poll or not self.easee.sr_is_connected():
             self._first_equalizer_poll = False
             for equalizer_data in self.equalizers_data:
-                equalizer_data.state = await equalizer_data.equalizer.get_state()
-                if equalizer_data.state["isOnline"]:
-                    equalizer_data.state["isOnline"] = ONLINE
-                else:
-                    equalizer_data.state["isOnline"] = OFFLINE
+                equalizer_data.state = await equalizer_data.product.get_state()
 
         self.update_equalizers_state()
 
@@ -407,7 +409,7 @@ class Controller:
         return self.circuits
 
     def get_binary_sensor_entities(self):
-        return self.binary_sensor_entities
+        return self.binary_sensor_entities + self.equalizer_binary_sensor_entities
 
     def get_sensor_entities(self):
         return self.sensor_entities + self.equalizer_sensor_entities
@@ -430,6 +432,7 @@ class Controller:
         self.switch_entities = []
         self.binary_sensor_entities = []
         self.equalizer_sensor_entities = []
+        self.equalizer_binary_sensor_entities = []
 
         all_easee_entities = {**MANDATORY_EASEE_ENTITIES, **OPTIONAL_EASEE_ENTITIES}
 
@@ -446,7 +449,7 @@ class Controller:
                         "Adding sensor entity: %s (%s) for charger %s",
                         key,
                         entity_type,
-                        charger_data.charger.name,
+                        charger_data.product.name,
                     )
 
                     if data["units"] in custom_units:
@@ -455,7 +458,7 @@ class Controller:
                     self.sensor_entities.append(
                         ChargerSensor(
                             controller=self,
-                            charger_data=charger_data,
+                            data=charger_data,
                             name=key,
                             state_key=data["key"],
                             units=data["units"],
@@ -473,12 +476,12 @@ class Controller:
                         "Adding switch entity: %s (%s) for charger %s",
                         key,
                         entity_type,
-                        charger_data.charger.name,
+                        charger_data.product.name,
                     )
                     self.switch_entities.append(
                         ChargerSwitch(
                             controller=self,
-                            charger_data=charger_data,
+                            data=charger_data,
                             name=key,
                             state_key=data["key"],
                             units=data["units"],
@@ -497,12 +500,12 @@ class Controller:
                         "Adding binary sensor entity: %s (%s) for charger %s",
                         key,
                         entity_type,
-                        charger_data.charger.name,
+                        charger_data.product.name,
                     )
                     self.binary_sensor_entities.append(
                         ChargerBinarySensor(
                             controller=self,
-                            charger_data=charger_data,
+                            data=charger_data,
                             name=key,
                             state_key=data["key"],
                             units=data["units"],
@@ -529,7 +532,7 @@ class Controller:
                         "Adding sensor entity: %s (%s) for equalizer %s",
                         key,
                         entity_type,
-                        equalizer_data.equalizer["name"],
+                        equalizer_data.product.name,
                     )
 
                     if data["units"] in custom_units:
@@ -538,7 +541,35 @@ class Controller:
                     self.equalizer_sensor_entities.append(
                         EqualizerSensor(
                             controller=self,
-                            charger_data=equalizer_data,
+                            data=equalizer_data,
+                            name=key,
+                            state_key=data["key"],
+                            units=data["units"],
+                            convert_units_func=convert_units_funcs.get(
+                                data["convert_units_func"], None
+                            ),
+                            attrs_keys=data["attrs"],
+                            device_class=data["device_class"],
+                            icon=data["icon"],
+                            state_func=data.get("state_func", None),
+                        )
+                    )
+
+                elif entity_type == "eq_binary_sensor":
+                    _LOGGER.debug(
+                        "Adding binary sensor entity: %s (%s) for equalizer %s",
+                        key,
+                        entity_type,
+                        equalizer_data.product.name,
+                    )
+
+                    if data["units"] in custom_units:
+                        data["units"] = CUSTOM_UNITS_TABLE[data["units"]]
+
+                    self.equalizer_binary_sensor_entities.append(
+                        EqualizerBinarySensor(
+                            controller=self,
+                            data=equalizer_data,
                             name=key,
                             state_key=data["key"],
                             units=data["units"],

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -41,6 +41,7 @@ from .const import (
     EASEE_EQ_ENTITIES,
     MANDATORY_EASEE_ENTITIES,
     OPTIONAL_EASEE_ENTITIES,
+    PLATFORMS,
     TIMEOUT,
 )
 from .entity import convert_units_funcs
@@ -284,7 +285,7 @@ class Controller:
         _LOGGER.debug(f"Entities {name} setup done")
         self._init_count = self._init_count + 1
 
-        if self._init_count == 3 and self.running_loop is not None:
+        if self._init_count >= len(PLATFORMS) and self.running_loop is not None:
             asyncio.run_coroutine_threadsafe(self.add_schedulers(), self.event_loop)
 
     def update_ha_state(self):

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -18,8 +18,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Setup sensor platform."""
     controller = hass.data[DOMAIN]["controller"]
     entities = controller.get_sensor_entities()
-
     async_add_entities(entities)
+    controller.setup_done("sensor")
 
 
 class ChargerSensor(ChargerEntity):

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import Dict
 
 from .const import DOMAIN
-from .entity import ChargerEntity, round_0_dec, round_1_dec
+from .entity import ChargerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,73 +40,11 @@ class EqualizerSensor(ChargerEntity):
         return self._state
 
     @property
-    def name(self):
-        """Return the name of the entity."""
-        return (
-            f"{self.charger_data.equalizer['name']} "
-            + f"{self._entity_name}".capitalize().replace("_", " ")
-        )
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self.charger_data.equalizer['name']}_{self._entity_name}"
-
-    @property
     def device_info(self) -> Dict[str, any]:
         """Return the device information."""
         return {
-            "identifiers": {(DOMAIN, self.charger_data.equalizer.id)},
-            "name": self.charger_data.equalizer["name"],
+            "identifiers": {(DOMAIN, self.data.product.id)},
+            "name": self.data.product.name,
             "manufacturer": "Easee",
             "model": "Equalizer",
         }
-
-    async def async_update(self):
-        """Get the latest data and update the state."""
-        _LOGGER.debug(
-            "EqualizerEntity async_update : %s %s",
-            self.charger_data.equalizer.id,
-            self._entity_name,
-        )
-        try:
-            self._state = self.get_value_from_key(self._state_key)
-            if self._state_func is not None:
-                if self._state_key.startswith("state"):
-                    self._state = self._state_func(self.charger_data.state)
-                if self._state_key.startswith("config"):
-                    self._state = self._state_func(self.charger_data.config)
-            if self._convert_units_func is not None:
-                self._state = self._convert_units_func(self._state, self._units)
-
-        except IndexError:
-            raise IndexError("Wrong key for entity: %s", self._state_key)
-
-    @property
-    def state_attributes(self):
-        """Return the state attributes."""
-        try:
-            attrs = {
-                "name": self.charger_data.equalizer["name"],
-                "id": self.charger_data.equalizer.id,
-            }
-            for attr_key in self._attrs_keys:
-                key = attr_key.replace(".", "_")
-                if "voltage" in key.lower():
-                    attrs[key] = round_0_dec(self.get_value_from_key(attr_key))
-                elif "current" in key.lower():
-                    attrs[key] = round_1_dec(self.get_value_from_key(attr_key))
-                elif "cumulative" in key.lower():
-                    attrs[key] = round_1_dec(
-                        self.get_value_from_key(attr_key), self._units
-                    )
-                elif "power" in key.lower():
-                    attrs[key] = round_1_dec(
-                        self.get_value_from_key(attr_key), self._units
-                    )
-                else:
-                    attrs[key] = self.get_value_from_key(attr_key)
-
-            return attrs
-        except IndexError:
-            return {}

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -26,7 +26,7 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         self.set_value_from_key(self._state_key, True)
         self._state = True
         self.async_write_ha_state()
-        function_call = getattr(self.charger_data.charger, self._switch_func)
+        function_call = getattr(self.data.product, self._switch_func)
         await function_call(True)
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
@@ -35,7 +35,7 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         self.set_value_from_key(self._state_key, False)
         self._state = False
         self.async_write_ha_state()
-        function_call = getattr(self.charger_data.charger, self._switch_func)
+        function_call = getattr(self.data.product, self._switch_func)
         await function_call(False)
 
     @property

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -15,6 +15,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     controller = hass.data[DOMAIN]["controller"]
     entities = controller.get_switch_entities()
     async_add_entities(entities)
+    controller.setup_done("switch")
 
 
 class ChargerSwitch(ChargerEntity, SwitchEntity):

--- a/custom_components/easee/translations/sensor.en.json
+++ b/custom_components/easee/translations/sensor.en.json
@@ -8,10 +8,6 @@
       "completed": "Completed",
       "ready_to_charge": "Ready to charge"
     },
-    "easee__eq_status": {
-      "online": "Online",
-      "offline": "Offline"
-    },
     "easee__reason_no_current": {
       "none": "None",
       "ok": "OK",

--- a/custom_components/easee/translations/sensor.nb.json
+++ b/custom_components/easee/translations/sensor.nb.json
@@ -8,10 +8,6 @@
       "completed": "Fullført",
       "ready_to_charge": "Klar til lading"
     },
-    "easee__eq_status": {
-      "online": "Online",
-      "offline": "Offline"
-    },
     "easee__reason_no_current": {
       "none": "Ingen",
       "ok": "OK",

--- a/custom_components/easee/translations/sensor.sv.json
+++ b/custom_components/easee/translations/sensor.sv.json
@@ -8,10 +8,6 @@
       "completed": "Klar",
       "ready_to_charge": "Redo för laddning"
     },
-    "easee__eq_status": {
-      "online": "Ansluten",
-      "offline": "Ej ansluten"
-    },
     "easee__reason_no_current": {
       "none": "Ingen",
       "ok": "OK",


### PR DESCRIPTION
Equalizer "status" sensor change name to "online" to better match the charger sensors.
Equalizer "online" sensor changed to binary_sensor.
Code cleanup that enables more code sharing between charger and equalizer sensors. As a result, the unique IDs of the equalizer sensors had to change, making this a breaking change.
Race condition fix, the schedulers for sensor updates are not started from __init.py__ file anymore, but instead by a call-back when all entities have been created.
Microseconds removed from latestPulse timestamp.
