### PR TITLE
Sensor name changes

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -95,7 +95,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "icon": "mdi:lock",
         "switch_func": "lockCablePermanently",
     },
-    "total_power": {
+    "power": {
         "key": "state.totalPower",
         "attrs": [],
         "units": POWER_KILO_WATT,
@@ -143,7 +143,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_CONNECTIVITY,
         "icon": None,
     },
-    "output_current": {
+    "output_limit": {
         "key": "state.outputCurrent",
         "attrs": [],
         "units": ELECTRICAL_CURRENT_AMPERE,
@@ -151,10 +151,9 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_CURRENT,
         "icon": None,
     },
-    "in_current": {
+    "current": {
         "key": "state.inCurrentT2",
         "attrs": [
-            "state.outputCurrent",
             "state.inCurrentT2",
             "state.inCurrentT3",
             "state.inCurrentT4",
@@ -205,7 +204,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
     },
-    "dynamic_circuit_current": {
+    "dynamic_circuit_limit": {
         "key": "state.dynamicCircuitCurrentP1",
         "attrs": [
             "circuit.id",
@@ -228,7 +227,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
     },
-    "max_circuit_current": {
+    "max_circuit_limit": {
         "key": "config.circuitMaxCurrentP1",
         "attrs": [
             "circuit.id",
@@ -251,7 +250,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
     },
-    "dynamic_charger_current": {
+    "dynamic_charger_limit": {
         "key": "state.dynamicChargerCurrent",
         "attrs": [
             "state.dynamicChargerCurrent",
@@ -261,7 +260,30 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_CURRENT,
         "icon": None,
     },
-    "max_charger_current": {
+    "offline_circuit_limit": {
+        "key": "state.offlineMaxCircuitCurrentP1",
+        "attrs": [
+            "circuit.id",
+            "circuit.circuitPanelId",
+            "circuit.panelName",
+            "circuit.ratedCurrent",
+            "state.offlineMaxCircuitCurrentP1",
+            "state.offlineMaxCircuitCurrentP2",
+            "state.offlineMaxCircuitCurrentP3",
+        ],
+        "units": ELECTRICAL_CURRENT_AMPERE,
+        "convert_units_func": "round_0_dec",
+        "device_class": DEVICE_CLASS_CURRENT,
+        "icon": None,
+        "state_func": lambda state: float(
+            max(
+                state["offlineMaxCircuitCurrentP1"],
+                state["offlineMaxCircuitCurrentP2"],
+                state["offlineMaxCircuitCurrentP3"],
+            )
+        ),
+    },
+    "max_charger_limit": {
         "key": "config.maxChargerCurrent",
         "attrs": [
             "config.maxChargerCurrent",

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -82,7 +82,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "icon": None,
         "state_func": lambda state: not bool(state["cableLocked"]),
     },
-    "permanent_cable_lock": {
+    "cable_locked_permanently": {
         "type": "switch",
         "key": "state.lockCablePermanently",
         "attrs": [

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -69,7 +69,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "icon": "mdi:auto-fix",
         "switch_func": "smart_charging",
     },
-    "cable_locked_car": {
+    "cable_locked": {
         "type": "binary_sensor",
         "key": "state.cableLocked",
         "attrs": [
@@ -82,7 +82,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "icon": None,
         "state_func": lambda state: not bool(state["cableLocked"]),
     },
-    "cable_permanently_locked_charger": {
+    "permanent_cable_lock": {
         "type": "switch",
         "key": "state.lockCablePermanently",
         "attrs": [

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -76,6 +76,7 @@ class ChargerEntity(Entity):
         icon: str,
         state_func=None,
         switch_func=None,
+        enabled_default=True,
     ):
 
         """Initialize the entity."""
@@ -91,7 +92,8 @@ class ChargerEntity(Entity):
         self._state_func = state_func
         self._state = None
         self._switch_func = switch_func
-
+        self._enabled_default = enabled_default
+        
     async def async_added_to_hass(self) -> None:
         """Entity created."""
 
@@ -124,6 +126,10 @@ class ChargerEntity(Entity):
                 return
 
             ent_reg.async_remove(self.entity_id)
+
+    @property
+    def entity_registry_enabled_default(self):
+        return self._enabled_default
 
     @property
     def name(self):

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -93,7 +93,7 @@ class ChargerEntity(Entity):
         self._state = None
         self._switch_func = switch_func
         self._enabled_default = enabled_default
-        
+
     async def async_added_to_hass(self) -> None:
         """Entity created."""
 

--- a/custom_components/easee/manifest.json
+++ b/custom_components/easee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/fondberg/easee_hass",
   "issue_tracker": "https://github.com/fondberg/easee_hass/issues",
   "requirements": [
-    "pyeasee==0.7.34"
+    "pyeasee==0.7.35"
   ],
   "config_flow": true,
   "codeowners": [

--- a/custom_components/easee/services.py
+++ b/custom_components/easee/services.py
@@ -133,32 +133,32 @@ SERVICE_MAP = {
         "function_call": "delete_basic_charge_plan",
         "schema": SERVICE_CHARGER_ACTION_COMMAND_SCHEMA,
     },
-    "set_circuit_dynamic_current": {
+    "set_circuit_dynamic_limit": {
         "handler": "circuit_execute_set_current",
         "function_call": "set_dynamic_current",
         "schema": SERVICE_SET_CIRCUIT_CURRENT_SCHEMA,
     },
-    "set_circuit_max_current": {
+    "set_circuit_max_limit": {
         "handler": "circuit_execute_set_current",
         "function_call": "set_max_current",
         "schema": SERVICE_SET_CIRCUIT_CURRENT_SCHEMA,
     },
-    "set_charger_circuit_dynamic_current": {
+    "set_charger_circuit_dynamic_limit": {
         "handler": "charger_execute_set_circuit_current",
         "function_call": "set_dynamic_charger_circuit_current",
         "schema": SERVICE_SET_CHARGER_CIRCUIT_CURRENT_SCHEMA,
     },
-    "set_charger_circuit_max_current": {
+    "set_charger_circuit_max_limit": {
         "handler": "charger_execute_set_circuit_current",
         "function_call": "set_max_charger_circuit_current",
         "schema": SERVICE_SET_CHARGER_CIRCUIT_CURRENT_SCHEMA,
     },
-    "set_charger_dynamic_current": {
+    "set_charger_dynamic_limit": {
         "handler": "charger_execute_set_current",
         "function_call": "set_dynamic_charger_current",
         "schema": SERVICE_SET_CHARGER_CURRENT_SCHEMA,
     },
-    "set_charger_max_current": {
+    "set_charger_max_limit": {
         "handler": "charger_execute_set_current",
         "function_call": "set_max_charger_current",
         "schema": SERVICE_SET_CHARGER_CURRENT_SCHEMA,

--- a/custom_components/easee/services.yaml
+++ b/custom_components/easee/services.yaml
@@ -84,8 +84,8 @@ update_firmware:
       description: "The charger id"
       example: "EH123456"
 
-set_circuit_dynamic_current:
-  description: "Set circuit dynamic current (current available to share by all chargers on a circuit)."
+set_circuit_dynamic_limit:
+  description: "Set circuit dynamic limit (current available to share by all chargers on a circuit)."
   fields:
     circuit_id:
       description: "The circuit id"
@@ -100,8 +100,8 @@ set_circuit_dynamic_current:
       description: "Phase 3 current (Optional)"
       example: 10
 
-set_circuit_max_current:
-  description: "Set circuit max current. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
+set_circuit_max_limit:
+  description: "Set circuit max limit. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
   fields:
     circuit_id:
       description: "The circuit id"
@@ -116,8 +116,8 @@ set_circuit_max_current:
       description: "Phase 3 current (Optional)"
       example: 10
 
-set_charger_circuit_dynamic_current:
-  description: "Set circuit dynamic current (current available to share by all chargers on a circuit)."
+set_charger_circuit_dynamic_limit:
+  description: "Set circuit dynamic limit (current available to share by all chargers on a circuit)."
   fields:
     charger_id:
       description: "The charger id"
@@ -132,8 +132,8 @@ set_charger_circuit_dynamic_current:
       description: "Phase 3 current (Optional)"
       example: 10
 
-set_charger_circuit_max_current:
-  description: "Set circuit max current. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
+set_charger_circuit_max_limit:
+  description: "Set circuit max limit. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
   fields:
     charger_id:
       description: "The charger id"
@@ -148,8 +148,8 @@ set_charger_circuit_max_current:
       description: "Phase 3 current (Optional)"
       example: 10
 
-set_charger_dynamic_current:
-  description: "Set charger dynamic current"
+set_charger_dynamic_limit:
+  description: "Set charger dynamic limit"
   fields:
     charger_id:
       description: "The charger id"
@@ -158,8 +158,8 @@ set_charger_dynamic_current:
       description: "Charger current"
       example: 10
 
-set_charger_max_current:
-  description: "Set charger max current. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
+set_charger_max_limit:
+  description: "Set charger max limit. Caution! Should not be used by automation (may wear out flash memory if set too frequently)."
   fields:
     charger_id:
       description: "The charger id"

--- a/custom_components/easee/translations/sensor.sv.json
+++ b/custom_components/easee/translations/sensor.sv.json
@@ -17,7 +17,7 @@
       "circuit_fuse_too_low": "Kretssäkring för låg",
       "waiting_in_queue": "Väntar i kö",
       "waiting_in_fully": "Waiting in fully",
-      "illegal_grid_type": "Otillåten nättyp",
+      "illegal_grid_type": "Otillåten elnätstyp",
       "no_current_request": "Ingen begäran om ström från sekundär enhet",
       "not_requesting_current": "Sekundär enhet begär ingen ström",
       "max_charger_current_too_low": "Laddarens maxström för låg",


### PR DESCRIPTION
All current limits are now called limits instead of current.
in_current is now called current.
cable_locked_car is now called cable_locked.
cable_permanently_locked_charger is now called permanent_cable_lock.
Small swedish translation change.
Adding support for entity_registry_enabled_default to prepare for future support for disabled sensors at first install.
