### PR TITLE
Add support for long-term statistics and energy module

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -414,14 +414,24 @@ EASEE_EQ_ENTITIES = {
         "device_class": DEVICE_CLASS_CONNECTIVITY,
         "icon": None,
     },
-    "power": {
+    "import_power": {
         "key": "state.activePowerImport",
         "attrs": [
             "state.activePowerImport",
-            "state.activePowerExport",
             "state.reactivePowerImport",
-            "state.reactivePowerExport",
             "state.maxPowerImport",
+        ],
+        "units": POWER_KILO_WATT,
+        "convert_units_func": "round_1_dec",
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "icon": None,
+    },
+    "export_power": {
+        "key": "state.activePowerExport",
+        "attrs": [
+            "state.activePowerExport",
+            "state.reactivePowerExport",
         ],
         "units": POWER_KILO_WATT,
         "convert_units_func": "round_1_dec",
@@ -475,12 +485,23 @@ EASEE_EQ_ENTITIES = {
             )
         ),
     },
-    "energy": {
+    "import_energy": {
         "key": "state.cumulativeActivePowerImport",
         "attrs": [
             "state.cumulativeActivePowerImport",
-            "state.cumulativeActivePowerExport",
             "state.cumulativeReactivePowerImport",
+        ],
+        "units": ENERGY_KILO_WATT_HOUR,
+        "convert_units_func": "round_1_dec",
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "last_reset": dt.utc_from_timestamp(0),
+        "icon": None,
+    },
+    "export_energy": {
+        "key": "state.cumulativeActivePowerExport",
+        "attrs": [
+            "state.cumulativeActivePowerExport",
             "state.cumulativeReactivePowerExport",
         ],
         "units": ENERGY_KILO_WATT_HOUR,

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -3,6 +3,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_LOCK,
 )
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
 from homeassistant.const import (
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
@@ -13,6 +14,7 @@ from homeassistant.const import (
     POWER_KILO_WATT,
     POWER_WATT,
 )
+from homeassistant.util import dt
 
 # For backwards compatibility for HA before v2021.8
 try:
@@ -106,6 +108,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": POWER_KILO_WATT,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
     },
     "session_energy": {
@@ -122,6 +125,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": ENERGY_KILO_WATT_HOUR,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "last_reset": dt.utc_from_timestamp(0),
         "icon": "mdi:counter",
     },
     "energy_per_hour": {
@@ -167,6 +172,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": ELECTRIC_CURRENT_AMPERE,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
         "state_func": lambda state: float(
             max(
@@ -315,6 +321,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": ELECTRIC_POTENTIAL_VOLT,
         "convert_units_func": "round_0_dec",
         "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
     },
     "reason_for_no_current": {
@@ -419,6 +426,7 @@ EASEE_EQ_ENTITIES = {
         "units": POWER_KILO_WATT,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
     },
     "voltage": {
@@ -434,6 +442,7 @@ EASEE_EQ_ENTITIES = {
         "units": ELECTRIC_POTENTIAL_VOLT,
         "convert_units_func": "round_0_dec",
         "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
         "state_func": lambda state: float(
             max(
@@ -456,6 +465,7 @@ EASEE_EQ_ENTITIES = {
         "units": ELECTRIC_CURRENT_AMPERE,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
         "state_func": lambda state: float(
             max(
@@ -476,6 +486,8 @@ EASEE_EQ_ENTITIES = {
         "units": ENERGY_KILO_WATT_HOUR,
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "last_reset": dt.utc_from_timestamp(0),
         "icon": None,
     },
 }

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -461,7 +461,7 @@ class Controller:
             icon=data["icon"],
             state_func=data.get("state_func", None),
             switch_func=data.get("switch_func", None),
-            enabled_default=data.get("enabled_default", None),
+            enabled_default=data.get("enabled_default", True),
         )
         _LOGGER.debug(
             "Adding entity: %s (%s) for product %s",

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -456,9 +456,12 @@ class Controller:
             ),
             attrs_keys=data["attrs"],
             device_class=data["device_class"],
+            state_class=data.get("state_class", None),
+            last_reset=data.get("last_reset", None),
             icon=data["icon"],
             state_func=data.get("state_func", None),
             switch_func=data.get("switch_func", None),
+            enabled_default=data.get("enabled_default", None),
         )
         _LOGGER.debug(
             "Adding entity: %s (%s) for product %s",

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -6,7 +6,8 @@ import logging
 from datetime import datetime
 from typing import Callable, Dict, List
 
-from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+from homeassistant.const import DEVICE_CLASS_ENERGY, ENERGY_WATT_HOUR, POWER_WATT
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import async_entries_for_device
@@ -77,6 +78,8 @@ class ChargerEntity(Entity):
         state_func=None,
         switch_func=None,
         enabled_default=True,
+        state_class=None,
+        last_reset=None,
     ):
 
         """Initialize the entity."""
@@ -93,6 +96,15 @@ class ChargerEntity(Entity):
         self._state = None
         self._switch_func = switch_func
         self._enabled_default = enabled_default
+        self._last_reset = last_reset
+        self._attr_state_class = state_class
+
+        if (
+            device_class == DEVICE_CLASS_ENERGY
+            and state_class == STATE_CLASS_MEASUREMENT
+        ):
+            self._attr_last_reset = last_reset
+            _LOGGER.debug("Setting last_reset for %s: %s", name, last_reset)
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
@@ -173,6 +185,8 @@ class ChargerEntity(Entity):
                 "name": self.data.product.name,
                 "id": self.data.product.id,
             }
+            if hasattr(self, "_attr_last_reset") and self._attr_last_reset is not None:
+                attrs["last_reset"] = self._attr_last_reset
             for attr_key in self._attrs_keys:
                 key = attr_key.replace(".", "_")
                 if "voltage" in key.lower():

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -2,9 +2,12 @@
 Easee charger sensor
 Author: Niklas Fondberg<niklas.fondberg@gmail.com>
 """
+
 import logging
 from datetime import timedelta
 from typing import Dict
+
+from homeassistant.components.sensor import SensorEntity
 
 from .const import DOMAIN
 from .entity import ChargerEntity
@@ -22,7 +25,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     controller.setup_done("sensor")
 
 
-class ChargerSensor(ChargerEntity):
+class ChargerSensor(ChargerEntity, SensorEntity):
     """Implementation of Easee charger sensor."""
 
     @property
@@ -31,7 +34,7 @@ class ChargerSensor(ChargerEntity):
         return self._state
 
 
-class EqualizerSensor(ChargerEntity):
+class EqualizerSensor(ChargerEntity, SensorEntity):
     """Implementation of Easee equalizer sensor."""
 
     @property


### PR DESCRIPTION
Adds support for long-term statistics and use of power and energy sensors in energy panel. Addresses issues #129 #130 .
Note that HA currently(2021.8) accumulates data for a limited set of device_classes. Power and accumulated energy sensors are supported. Voltage and current are not supported.
Data will not be displayed until after approximately two hours of data collection.  
### Breaking change
Power and energy sensors for Equalizer are split up in separate sensors for import and export. This simplifies the use of these sensors in the energy module. Users that use the old power or energy sensors or their attributes in automations or template sensors should review and modify the configuration.