### PR TITLE
Add configuration_url to device_info

### DIFF
--- a/custom_components/easee/binary_sensor.py
+++ b/custom_components/easee/binary_sensor.py
@@ -46,4 +46,5 @@ class EqualizerBinarySensor(ChargerEntity, BinarySensorEntity):
             "name": self.data.product.name,
             "manufacturer": "Easee",
             "model": "Equalizer",
+            "configuration_url": f"https://easee.cloud/mypage/products/{self.data.product.id}",
         }

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -155,6 +155,7 @@ class ChargerEntity(Entity):
             "name": self.data.product.name,
             "manufacturer": "Easee",
             "model": "Charging Robot",
+            "configuration_url": f"https://easee.cloud/mypage/products/{self.data.product.id}",
         }
 
     @property

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -50,4 +50,5 @@ class EqualizerSensor(ChargerEntity, SensorEntity):
             "name": self.data.product.name,
             "manufacturer": "Easee",
             "model": "Equalizer",
+            "configuration_url": f"https://easee.cloud/mypage/products/{self.data.product.id}",
         }


### PR DESCRIPTION
New feature in HA 2021.11
Display "Visit Device" link on device info page. Points at "My Products" in Easee cloud.