### PR TITLE
Rework entity creation

### DIFF
--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -73,3 +73,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.info("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+
+        options = {**config_entry.options}
+        # modify Config Entry data
+        if "monitored_conditions" in options:
+            options.pop("monitored_conditions")
+
+        if "monitored_eq_conditions" in options:
+            options.pop("monitored_eq_conditions")
+
+        config_entry.options = {**options}
+
+        config_entry.version = 2
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    return True

--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -23,8 +23,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
     hass.data[DOMAIN]["entities"] = []
-    hass.data[DOMAIN]["entities_to_remove"] = []
-    hass.data[DOMAIN]["eq_entities_to_remove"] = []
     hass.data[DOMAIN]["sites_to_remove"] = []
     _LOGGER.debug("Setting up Easee component version %s", VERSION)
     username = entry.data.get(CONF_USERNAME)

--- a/custom_components/easee/binary_sensor.py
+++ b/custom_components/easee/binary_sensor.py
@@ -1,9 +1,9 @@
 """Easee charger binary sensor."""
 
 import logging
-from typing import Dict
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
 from .entity import ChargerEntity
@@ -39,11 +39,11 @@ class EqualizerBinarySensor(ChargerEntity, BinarySensorEntity):
         return self._state
 
     @property
-    def device_info(self) -> Dict[str, any]:
+    def device_info(self):
         """Return the device information."""
-        return {
-            "identifiers": {(DOMAIN, self.data.product.id)},
-            "name": self.data.product.name,
-            "manufacturer": "Easee",
-            "model": "Equalizer",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.data.product.id)},
+            name=self.data.product.name,
+            manufacturer="Easee",
+            model="Equalizer",
+        )

--- a/custom_components/easee/binary_sensor.py
+++ b/custom_components/easee/binary_sensor.py
@@ -46,4 +46,5 @@ class EqualizerBinarySensor(ChargerEntity, BinarySensorEntity):
             name=self.data.product.name,
             manufacturer="Easee",
             model="Equalizer",
+            configuration_url=f"https://easee.cloud/mypage/products/{self.data.product.id}",
         )

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -96,9 +96,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 return await self._update_options()
         controller = self.hass.data[DOMAIN]["controller"]
         sites: List[Site] = controller.get_sites()
-        sites_multi_select = []
-        for site in sites:
-            sites_multi_select.append(site["name"])
+        sites_multi_select = {x["name"]: x["name"] for x in sites}
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -5,23 +5,14 @@ from typing import List, Optional
 import voluptuous as vol
 from aiohttp import ClientConnectionError
 from homeassistant import config_entries
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from pyeasee import AuthorizationFailedException, Easee, Site
 
-from .const import (
-    CONF_MONITORED_EQ_CONDITIONS,
-    CONF_MONITORED_SITES,
-    CUSTOM_UNITS,
-    CUSTOM_UNITS_OPTIONS,
-    DOMAIN,
-    EASEE_EQ_ENTITIES,
-    MANDATORY_EASEE_ENTITIES,
-    OPTIONAL_EASEE_ENTITIES,
-)
+from .const import CONF_MONITORED_SITES, CUSTOM_UNITS, CUSTOM_UNITS_OPTIONS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 class EaseeConfigFlow(config_entries.ConfigFlow):
     """Easee config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     @staticmethod
@@ -104,8 +95,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 self.options.update(user_input)
                 return await self._update_options()
         controller = self.hass.data[DOMAIN]["controller"]
-        sensor_multi_select = {x: x for x in list(OPTIONAL_EASEE_ENTITIES)}
-        sensor_eq_multi_select = {x: x for x in list(EASEE_EQ_ENTITIES)}
         sites: List[Site] = controller.get_sites()
         sites_multi_select = []
         for site in sites:
@@ -122,18 +111,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         ),
                     ): cv.multi_select(sites_multi_select),
                     vol.Optional(
-                        CONF_MONITORED_CONDITIONS,
-                        default=self.config_entry.options.get(
-                            CONF_MONITORED_CONDITIONS, []
-                        ),
-                    ): cv.multi_select(sensor_multi_select),
-                    vol.Optional(
-                        CONF_MONITORED_EQ_CONDITIONS,
-                        default=self.config_entry.options.get(
-                            CONF_MONITORED_EQ_CONDITIONS, ["online"]
-                        ),
-                    ): cv.multi_select(sensor_eq_multi_select),
-                    vol.Optional(
                         CUSTOM_UNITS,
                         default=self.config_entry.options.get(CUSTOM_UNITS, []),
                     ): cv.multi_select(CUSTOM_UNITS_OPTIONS),
@@ -143,20 +120,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def _update_options(self):
-        for x in self.options[CONF_MONITORED_CONDITIONS]:
-            if x in MANDATORY_EASEE_ENTITIES:
-                del self.options[CONF_MONITORED_CONDITIONS][x]
-        """Update config entry options."""
-        self.hass.data[DOMAIN]["entities_to_remove"] = [
-            cond
-            for cond in self.prev_options.get(CONF_MONITORED_CONDITIONS, {})
-            if cond not in self.options[CONF_MONITORED_CONDITIONS]
-        ]
-        self.hass.data[DOMAIN]["eq_entities_to_remove"] = [
-            cond
-            for cond in self.prev_options.get(CONF_MONITORED_EQ_CONDITIONS, {})
-            if cond not in self.options[CONF_MONITORED_EQ_CONDITIONS]
-        ]
         self.hass.data[DOMAIN]["sites_to_remove"] = [
             cond
             for cond in self.prev_options.get(CONF_MONITORED_SITES, {})

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -97,6 +97,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         controller = self.hass.data[DOMAIN]["controller"]
         sites: List[Site] = controller.get_sites()
         sites_multi_select = {x["name"]: x["name"] for x in sites}
+        default_sites = [x["name"] for x in sites]
 
         return self.async_show_form(
             step_id="init",
@@ -105,7 +106,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_MONITORED_SITES,
                         default=self.config_entry.options.get(
-                            CONF_MONITORED_SITES, sites_multi_select
+                            CONF_MONITORED_SITES, default_sites
                         ),
                     ): cv.multi_select(sites_multi_select),
                     vol.Optional(

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
 )
-from homeassistant.const import (
+from homeassistant.const import (  # ENTITY_CATEGORY_CONFIG,; ENTITY_CATEGORY_DIAGNOSTIC,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
@@ -17,6 +17,10 @@ from homeassistant.const import (
     POWER_KILO_WATT,
     POWER_WATT,
 )
+
+# Compatibility with HA <= 2021.10
+ENTITY_CATEGORY_CONFIG = "config"
+ENTITY_CATEGORY_DIAGNOSTIC = "diagnostic"
 
 # For backwards compatibility for HA before v2021.8
 try:
@@ -77,6 +81,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:auto-fix",
         "switch_func": "smart_charging",
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_CONFIG,
     },
     "cable_locked": {
         "type": "binary_sensor",
@@ -90,6 +96,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_LOCK,
         "icon": None,
         "state_func": lambda state: not bool(state["cableLocked"]),
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "cable_locked_permanently": {
         "type": "switch",
@@ -103,6 +110,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:lock",
         "switch_func": "lockCablePermanently",
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_CONFIG,
     },
     "power": {
         "key": "state.totalPower",
@@ -120,6 +129,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_ENERGY,
         "icon": None,
+        "enabled_default": False,
     },
     "lifetime_energy": {
         "key": "state.lifetimeEnergy",
@@ -161,6 +171,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_CURRENT,
         "icon": None,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "current": {
         "key": "state.inCurrentT2",
@@ -183,6 +195,8 @@ OPTIONAL_EASEE_ENTITIES = {
                 state["inCurrentT5"],
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "circuit_current": {
         "key": "state.circuitTotalPhaseConductorCurrentL1",
@@ -215,6 +229,7 @@ OPTIONAL_EASEE_ENTITIES = {
                 else 0.0,
             )
         ),
+        "enabled_default": False,
     },
     "dynamic_circuit_limit": {
         "key": "state.dynamicCircuitCurrentP1",
@@ -238,6 +253,8 @@ OPTIONAL_EASEE_ENTITIES = {
                 state["dynamicCircuitCurrentP3"],
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "max_circuit_limit": {
         "key": "config.circuitMaxCurrentP1",
@@ -261,6 +278,8 @@ OPTIONAL_EASEE_ENTITIES = {
                 config["circuitMaxCurrentP3"],
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "dynamic_charger_limit": {
         "key": "state.dynamicChargerCurrent",
@@ -271,6 +290,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "device_class": DEVICE_CLASS_CURRENT,
         "icon": None,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "offline_circuit_limit": {
         "key": "state.offlineMaxCircuitCurrentP1",
@@ -294,6 +315,8 @@ OPTIONAL_EASEE_ENTITIES = {
                 state["offlineMaxCircuitCurrentP3"],
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "max_charger_limit": {
         "key": "config.maxChargerCurrent",
@@ -304,6 +327,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "device_class": DEVICE_CLASS_CURRENT,
         "icon": None,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "voltage": {
         "key": "state.inVoltageT2T3",
@@ -324,6 +349,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
         "icon": None,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "reason_for_no_current": {
         "key": "state.reasonForNoCurrent",
@@ -332,6 +359,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "map_reason_no_current",
         "device_class": "easee__reason_no_current",
         "icon": "mdi:alert-circle",
+        "enabled_default": False,
     },
     "is_enabled": {
         "type": "switch",
@@ -352,6 +380,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:current-ac",
         "switch_func": "enable_idle_current",
+        "entity_category": ENTITY_CATEGORY_CONFIG,
     },
     "update_available": {
         "type": "binary_sensor",
@@ -366,6 +395,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "icon": "mdi:file-download",
         "state_func": lambda state: int(state["chargerFirmware"])
         < int(state["latestFirmware"]),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "basic_schedule": {
         "type": "binary_sensor",
@@ -382,6 +413,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:clock-check",
         "state_func": lambda schedule: bool(schedule.isEnabled) or False,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "weekly_schedule": {
         "type": "binary_sensor",
@@ -408,6 +441,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:clock-check",
         "state_func": lambda weekly_schedule: bool(weekly_schedule.isEnabled) or False,
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "cost_per_kwh": {
         "key": "site.costPerKWh",
@@ -422,6 +457,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "device_class": None,
         "icon": "mdi:currency-usd",
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
 }
 
@@ -492,6 +529,8 @@ EASEE_EQ_ENTITIES = {
                 state["voltageL2L3"] or 0.0,
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "current": {
         "key": "state.currentL1",
@@ -512,6 +551,8 @@ EASEE_EQ_ENTITIES = {
                 state["currentL3"],
             )
         ),
+        "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "import_energy": {
         "key": "state.cumulativeActivePowerImport",

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -33,7 +33,6 @@ DOMAIN = "easee"
 TIMEOUT = 30
 VERSION = "0.9.34"
 CONF_MONITORED_SITES = "monitored_sites"
-CONF_MONITORED_EQ_CONDITIONS = "monitored_eq_conditions"
 CUSTOM_UNITS = "custom_units"
 PLATFORMS = ("sensor", "switch", "binary_sensor")
 LISTENER_FN_CLOSE = "update_listener_close_fn"

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -73,7 +73,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:auto-fix",
         "switch_func": "smart_charging",
-        "enabled_default": False,
+        "enabled_default": True,
         "entity_category": ENTITY_CATEGORY_CONFIG,
     },
     "cable_locked": {
@@ -102,7 +102,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": None,
         "icon": "mdi:lock",
         "switch_func": "lockCablePermanently",
-        "enabled_default": False,
+        "enabled_default": True,
         "entity_category": ENTITY_CATEGORY_CONFIG,
     },
     "power": {
@@ -121,7 +121,8 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_ENERGY,
         "icon": None,
-        "enabled_default": False,
+        "enabled_default": True,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "lifetime_energy": {
         "key": "state.lifetimeEnergy",
@@ -131,6 +132,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": DEVICE_CLASS_ENERGY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
         "icon": "mdi:counter",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "energy_per_hour": {
         "key": "state.energyPerHour",
@@ -139,6 +141,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_1_dec",
         "device_class": DEVICE_CLASS_ENERGY,
         "icon": None,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "online": {
         "type": "binary_sensor",
@@ -155,6 +158,7 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "device_class": DEVICE_CLASS_CONNECTIVITY,
         "icon": None,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "output_limit": {
         "key": "state.outputCurrent",
@@ -222,6 +226,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
         "enabled_default": False,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "dynamic_circuit_limit": {
         "key": "state.dynamicCircuitCurrentP1",
@@ -557,6 +562,7 @@ EASEE_EQ_ENTITIES = {
         "device_class": DEVICE_CLASS_ENERGY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
         "icon": None,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     "export_energy": {
         "key": "state.cumulativeActivePowerExport",
@@ -569,6 +575,7 @@ EASEE_EQ_ENTITIES = {
         "device_class": DEVICE_CLASS_ENERGY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
         "icon": None,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
 }
 

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -7,27 +7,20 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
 )
-from homeassistant.const import (  # ENTITY_CATEGORY_CONFIG,; ENTITY_CATEGORY_DIAGNOSTIC,
+from homeassistant.const import (
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     POWER_KILO_WATT,
     POWER_WATT,
 )
-
-# Compatibility with HA <= 2021.10
-ENTITY_CATEGORY_CONFIG = "config"
-ENTITY_CATEGORY_DIAGNOSTIC = "diagnostic"
-
-# For backwards compatibility for HA before v2021.8
-try:
-    from homeassistant.const import ELECTRIC_CURRENT_AMPERE, ELECTRIC_POTENTIAL_VOLT
-except ImportError:
-    from homeassistant.const import ELECTRICAL_CURRENT_AMPERE as ELECTRIC_CURRENT_AMPERE
-    from homeassistant.const import VOLT as ELECTRIC_POTENTIAL_VOLT
 
 DOMAIN = "easee"
 TIMEOUT = 30

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -8,7 +8,6 @@ from typing import List
 
 from async_timeout import timeout
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, Unauthorized
 from homeassistant.helpers import aiohttp_client
@@ -33,7 +32,6 @@ from pyeasee.exceptions import (
 
 from .binary_sensor import ChargerBinarySensor, EqualizerBinarySensor
 from .const import (
-    CONF_MONITORED_EQ_CONDITIONS,
     CONF_MONITORED_SITES,
     CUSTOM_UNITS,
     CUSTOM_UNITS_TABLE,
@@ -490,15 +488,6 @@ class Controller:
         return entity
 
     def _create_entitites(self):
-        monitored_conditions = list(
-            dict.fromkeys(
-                self.config.options.get(CONF_MONITORED_CONDITIONS, [])
-                + [x for x in MANDATORY_EASEE_ENTITIES]
-            )
-        )
-        monitored_eq_conditions = self.config.options.get(
-            CONF_MONITORED_EQ_CONDITIONS, ["status"]
-        )
         self.sensor_entities = []
         self.switch_entities = []
         self.binary_sensor_entities = []
@@ -508,11 +497,7 @@ class Controller:
         all_easee_entities = {**MANDATORY_EASEE_ENTITIES, **OPTIONAL_EASEE_ENTITIES}
 
         for charger_data in self.chargers_data:
-            #  for key in monitored_conditions:
             for key in all_easee_entities:
-                # Fix renamed entities previously configured
-                if key not in all_easee_entities:
-                    continue
                 data = all_easee_entities[key]
                 entity_type = data.get("type", "sensor")
 
@@ -525,11 +510,7 @@ class Controller:
                 )
 
         for equalizer_data in self.equalizers_data:
-            #  for key in monitored_eq_conditions:
             for key in EASEE_EQ_ENTITIES:
-                # Fix renamed entities previously configured
-                if key not in EASEE_EQ_ENTITIES:
-                    continue
                 data = EASEE_EQ_ENTITIES[key]
                 entity_type = data.get("type", "eq_sensor")
 

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -147,7 +147,7 @@ class ProductData:
             if self.state["isOnline"] is True:
                 self.dirty = True
                 self.state["isOnline"] = False
-                _LOGGER.debug(f"Product {self.product.id} marked offline")
+                _LOGGER.debug("Product %s marked offline", self.product.id)
 
     def update_stream_data(self, data_type, data_id, value):
         if self.state is None:
@@ -161,10 +161,10 @@ class ProductData:
             name = self.streamdata(data_id).name
         except ValueError:
             # Unsupported data
-            _LOGGER.debug(f"Unsupported data id {data_id} {value}")
+            _LOGGER.debug("Unsupported data id %s %s", data_id, value)
             return False
 
-        _LOGGER.debug(f"Callback {self.product.id} {data_id} {name} {value}")
+        _LOGGER.debug("Callback %s %s %s %s", self.product.id, data_id, name, value)
 
         if "_" in name:
             first, second = name.split("_")

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -325,7 +325,7 @@ class Controller:
         )
 
         for entity in all_entities:
-            if entity.data.is_dirty():
+            if entity.enabled and entity.data.is_dirty():
                 entity.async_schedule_update_ha_state(True)
 
         for entity in all_entities:
@@ -464,6 +464,7 @@ class Controller:
             state_func=data.get("state_func", None),
             switch_func=data.get("switch_func", None),
             enabled_default=data.get("enabled_default", True),
+            entity_category=data.get("entity_category", None),
         )
         _LOGGER.debug(
             "Adding entity: %s (%s) for product %s",
@@ -507,7 +508,8 @@ class Controller:
         all_easee_entities = {**MANDATORY_EASEE_ENTITIES, **OPTIONAL_EASEE_ENTITIES}
 
         for charger_data in self.chargers_data:
-            for key in monitored_conditions:
+            #  for key in monitored_conditions:
+            for key in all_easee_entities:
                 # Fix renamed entities previously configured
                 if key not in all_easee_entities:
                     continue
@@ -523,7 +525,8 @@ class Controller:
                 )
 
         for equalizer_data in self.equalizers_data:
-            for key in monitored_eq_conditions:
+            #  for key in monitored_eq_conditions:
+            for key in EASEE_EQ_ENTITIES:
                 # Fix renamed entities previously configured
                 if key not in EASEE_EQ_ENTITIES:
                     continue

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -4,11 +4,11 @@ Author: Niklas Fondberg<niklas.fondberg@gmail.com>
 """
 import logging
 from datetime import datetime
-from typing import Callable, Dict, List
+from typing import Callable, List
 
 from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT
 from homeassistant.helpers import device_registry, entity_registry
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity, DeviceInfo
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.util import dt
 
@@ -146,14 +146,14 @@ class ChargerEntity(Entity):
         return f"{self.data.product.id}_{self._entity_name}"
 
     @property
-    def device_info(self) -> Dict[str, any]:
+    def device_info(self):
         """Return the device information."""
-        return {
-            "identifiers": {(DOMAIN, self.data.product.id)},
-            "name": self.data.product.name,
-            "manufacturer": "Easee",
-            "model": "Charging Robot",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.data.product.id)},
+            name=self.data.product.name,
+            manufacturer="Easee",
+            model="Charging Robot",
+        )
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -121,11 +121,7 @@ class ChargerEntity(Entity):
         device_entry = dev_reg.async_get(entity_entry.device_id)
 
         _LOGGER.debug("Removing _entity_name: %s", self._entity_name)
-        if (
-            self._entity_name in self.hass.data[DOMAIN]["entities_to_remove"]
-            or self._entity_name in self.hass.data[DOMAIN]["eq_entities_to_remove"]
-            or self.data.site.name in self.hass.data[DOMAIN]["sites_to_remove"]
-        ):
+        if self.data.site.name in self.hass.data[DOMAIN]["sites_to_remove"]:
             if len(async_entries_for_device(ent_reg, entity_entry.device_id)) == 1:
                 dev_reg.async_remove_device(device_entry.id)
                 return

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -78,6 +78,7 @@ class ChargerEntity(Entity):
         switch_func=None,
         enabled_default=True,
         state_class=None,
+        entity_category=None,
     ):
 
         """Initialize the entity."""
@@ -95,6 +96,7 @@ class ChargerEntity(Entity):
         self._switch_func = switch_func
         self._enabled_default = enabled_default
         self._attr_state_class = state_class
+        self._attr_entity_category = entity_category
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -153,6 +153,7 @@ class ChargerEntity(Entity):
             name=self.data.product.name,
             manufacturer="Easee",
             model="Charging Robot",
+            configuration_url=f"https://easee.cloud/mypage/products/{self.data.product.id}",
         )
 
     @property

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -283,8 +283,8 @@ class ChargerEntity(Entity):
             if self._convert_units_func is not None:
                 self._state = self._convert_units_func(self._state, self._units)
 
-        except IndexError:
-            raise IndexError("Wrong key for entity: %s", self._state_key)
+        except IndexError as exc:
+            raise IndexError(f"Wrong key for entity: {self._state_key}") from exc
         except TypeError:
             pass
         except AttributeError:

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -50,4 +50,5 @@ class EqualizerSensor(ChargerEntity, SensorEntity):
             name=self.data.product.name,
             manufacturer="Easee",
             model="Equalizer",
+            configuration_url=f"https://easee.cloud/mypage/products/{self.data.product.id}",
         )

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -5,9 +5,9 @@ Author: Niklas Fondberg<niklas.fondberg@gmail.com>
 
 import logging
 from datetime import timedelta
-from typing import Dict
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
 from .entity import ChargerEntity
@@ -43,11 +43,11 @@ class EqualizerSensor(ChargerEntity, SensorEntity):
         return self._state
 
     @property
-    def device_info(self) -> Dict[str, any]:
+    def device_info(self):
         """Return the device information."""
-        return {
-            "identifiers": {(DOMAIN, self.data.product.id)},
-            "name": self.data.product.name,
-            "manufacturer": "Easee",
-            "model": "Equalizer",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.data.product.id)},
+            name=self.data.product.name,
+            manufacturer="Easee",
+            model="Equalizer",
+        )

--- a/hacs.json
+++ b/hacs.json
@@ -5,7 +5,7 @@
     "sensor",
     "switch"
   ],
-  "homeassistant": "2021.9.0",
+  "homeassistant": "2021.11.0",
   "iot_class": [
     "Cloud Push"
   ]


### PR DESCRIPTION
### New way of selecting which entities to enable
All available entities are now created but only a selection based on `enabled_default` in const.py are enabled by default. The user can activate or deactivate the entities in the device info page.

### Done
- Migrate current options settings on first run of this version
- Remove monitored conditions from options page
- Remove monitored conditions from config_entry

### Remaining TODOs
- Decide on which sensors should be enabled by default
- Decide on enity_category for each entity - only valid from HA 2021.11