### PR TITLE
Add download counters to repo

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,36 +1,37 @@
-name-template: 'Example title - v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: "Example title - v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
 exclude-labels:
-  - 'skip-changelog'
+  - "skip-changelog"
 categories:
-  - title: 'New Features'
+  - title: "New Features"
     labels:
-      - 'feature'
-      - 'enhancement'
-  - title: 'Bug Fixes'
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
     labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: 'Dependencies'
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "Dependencies"
     labels:
-      - 'dependencies'
-  - title: 'Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+      - "dependencies"
+  - title: "Maintenance"
+    label: "chore"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 
 template: |
+  [![Downloads for this release](https://img.shields.io/github/downloads/fondberg/easee_hass/v$RESOLVED_VERSION/total.svg)](https://github.com/fondberg/easee_hass/releases/v$RESOLVED_VERSION)
+
   ## Changes
 
   $CHANGES
-  
+
 autolabeler:
-  - label: 'chore'
+  - label: "chore"
     files:
-      - '*.md'
-      - '.github/*'
-  - label: 'bugfix'
+      - "*.md"
+      - ".github/*"
+  - label: "bugfix"
     title:
-      - '/fix/i'
- 
+      - "/fix/i"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_zip_file:
+    name: Prepare release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      # Pack the easee dir as a zip and upload to the release
+      - name: ZIP easee Dir
+        run: |
+          cd ${{ github.workspace }}/custom_components/easee
+          zip easee.zip -r ./
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v1-release
+
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/custom_components/easee/easee.zip
+          asset_name: easee.zip
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/INFO.md
+++ b/INFO.md
@@ -1,14 +1,18 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2022.svg) [![Easee_downloads](https://img.shields.io/github/downloads/fondberg/easee_hass/total)](https://github.com/fondberg/easee_hass)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 
 # Easee EV charger component for Home Assistant
 
 {% if pending_update %}
+
 ## New version is available
+
 {% endif %}
 {% if prerelease %}
+
 ### NB!: This is a Beta version!
+
 {% endif %}
 
 Custom component to support Easee EV chargers.
@@ -33,4 +37,3 @@ Please help me test and preferbly suggest the fixes as a PR or technical note in
 Configuration is done through in Configuration > Integrations where you first configure it and then set the options for what you want to monitor.
 
 For full configuration documentation see [README](https://github.com/fondberg/easee_hass)
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2022.svg)
+[![easee_hass](https://img.shields.io/github/release/fondberg/easee_hass.svg?1)](https://github.com/fondberg/easee_hass) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) ![Validate with hassfest](https://github.com/fondberg/easee_hass/workflows/Validate%20with%20hassfest/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2022.svg) [![Easee_downloads](https://img.shields.io/github/downloads/fondberg/easee_hass/total)](https://github.com/fondberg/easee_hass)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)
 
@@ -25,7 +25,7 @@ There are 2 different methods of installing the custom component
 
 1. Add this repository from HACS->Integrations.
 2. Restart Home Assistant.
-2. Install the component from the Configuration->Integrations.
+3. Install the component from the Configuration->Integrations.
 
 ### Git installation
 

--- a/hacs.json
+++ b/hacs.json
@@ -8,5 +8,7 @@
   "homeassistant": "2021.11.0",
   "iot_class": [
     "Cloud Push"
-  ]
+  ],
+  "zip_release": true,
+  "filename": "easee.zip"
 }


### PR DESCRIPTION
Add download counters to the repo. 
The download counters built into Github requires that the downloads are packaged in "assets". This is done in the workflow relase.yml. A subsequent requirement is that HACS must download this asset. This is flagged in hacs.json.

The counter will just show zero until next release of easee_hass

![Skärmbild 2022-01-27 092421](https://user-images.githubusercontent.com/5016010/151320093-4ca0df97-7b1f-4b06-8052-719d4111e760.png)
