### PR TITLE
Let user select sites during initial setup

### DIFF
--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -6,7 +6,8 @@
     "error": {
       "auth_failure": "Unable to connect to Easee. Check your username and password.",
       "connection_failure": "Unable to connect to Easee. Test again later.",
-      "refused_failure": "Connection refused to Easee. Test again later."
+      "refused_failure": "Connection refused to Easee. Test again later.",
+      "no_sites": "No monitored sites selected"
     },
     "step": {
       "user": {
@@ -16,6 +17,13 @@
         },
         "description": "Please enter the username and password for your Easee account",
         "title": "Connect to Easee"
+      },
+      "sites": {
+        "data": {
+          "monitored_sites": "Sites"
+        },
+        "description": "Select sites to monitor",
+        "title": "Easee EV Charger"
       }
     }
   },

--- a/custom_components/easee/translations/nb.json
+++ b/custom_components/easee/translations/nb.json
@@ -6,7 +6,8 @@
     "error": {
       "auth_failure": "Kan ikke koble til Easee. Sjekk brukernavn og passord.",
       "connection_failure": "Kan ikke koble til Easee. Prøv igjen senere.",
-      "refused_failure": "Tilkobling til Easee ble avvist. Prøv igjen senere."
+      "refused_failure": "Tilkobling til Easee ble avvist. Prøv igjen senere.",
+      "no_sites": "Ingen lokasjon valgt"
     },
     "step": {
       "user": {
@@ -16,6 +17,13 @@
         },
         "description": "Vennligst fyll ut brukernavn og passord for din Easee-konto.",
         "title": "Koble til Easee"
+      },
+      "sites": {
+        "data": {
+          "monitored_sites": "Lokasjoner"
+        },
+        "description": "Velg lokasjoner",
+        "title": "Easee EV Charger"
       }
     }
   },

--- a/custom_components/easee/translations/sv.json
+++ b/custom_components/easee/translations/sv.json
@@ -6,7 +6,8 @@
     "error": {
       "auth_failure": "Autentisering misslyckades. Kontrollera användarnamn och lösenord.",
       "connection_failure": "Kan inte ansluta till Easee. Försök igen senare.",
-      "refused_failure": "Anslutning nekades till Easee. Försök igen senare."
+      "refused_failure": "Anslutning nekades till Easee. Försök igen senare.",
+      "no_sites": "Ingen plats vald"
     },
     "step": {
       "user": {
@@ -16,6 +17,13 @@
         },
         "description": "Ange användarnamn och lösenord för ditt Easee-konto",
         "title": "Anslut till Easee"
+      },
+      "sites": {
+        "data": {
+          "monitored_sites": "Platser"
+        },
+        "description": "Välj platser att monitorera",
+        "title": "Easee EV Charger"
       }
     }
   },


### PR DESCRIPTION
If the user's account contains more than one site the config flow will now open a second form that offers the possibility to select which sites that should be monitored.
This is a more intuitive flow where most users don't need to go back to "Configure" after initial setup.
Ref FR in #160 by @skela