### PR TITLE
Bump version i hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -5,7 +5,7 @@
     "sensor",
     "switch"
   ],
-  "homeassistant": "2021.11.0",
+  "homeassistant": "2022.1",
   "iot_class": [
     "Cloud Push"
   ],

--- a/hacs.json
+++ b/hacs.json
@@ -5,7 +5,7 @@
     "sensor",
     "switch"
   ],
-  "homeassistant": "2022.1",
+  "homeassistant": "2022.2",
   "iot_class": [
     "Cloud Push"
   ],


### PR DESCRIPTION
Require >= HA 2022.2
Integration will crash if installed on earlier versions of HA
Fixes #170 