### PR TITLE
Fix for empty backplates, diagnostics improvement.

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -290,12 +290,13 @@ class Controller:
                     )
                     self.circuits.append(circuit)
                     for charger in circuit.get_chargers():
-                        _LOGGER.debug("Found charger: %s %s", charger.id, charger.name)
-                        self.chargers.append(charger)
-                        charger_data = ProductData(
-                            self.event_loop, charger, site, ChargerStreamData, circuit
-                        )
-                        self.chargers_data.append(charger_data)
+                        if charger.id is not None:
+                            _LOGGER.debug("Found charger: %s %s", charger.id, charger.name)
+                            self.chargers.append(charger)
+                            charger_data = ProductData(
+                                self.event_loop, charger, site, ChargerStreamData, circuit
+                            )
+                            self.chargers_data.append(charger_data)
 
         self._init_count = 0
         self.trackers = []

--- a/custom_components/easee/diagnostics.py
+++ b/custom_components/easee/diagnostics.py
@@ -19,16 +19,10 @@ TO_REDACT_DATA = {}
 TO_REDACT_SITES = {
     "id",
     "siteKey",
-    "installerName",
-    "installerPhoneNumber",
-    "ownerName",
-    "ownerPhoneNumber",
+    "address",
+    "contactInfo",
     "siteId",
     "masterBackPlateId",
-    "street",
-    "buildingNumber",
-    "zip",
-    "area",
 }
 
 

--- a/custom_components/easee/diagnostics.py
+++ b/custom_components/easee/diagnostics.py
@@ -9,11 +9,27 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
+from .const import DOMAIN
+
 TO_REDACT = {
     CONF_PASSWORD,
     CONF_USERNAME,
 }
 TO_REDACT_DATA = {}
+TO_REDACT_SITES = {
+    "id",
+    "siteKey",
+    "installerName",
+    "installerPhoneNumber",
+    "ownerName",
+    "ownerPhoneNumber",
+    "siteId",
+    "masterBackPlateId",
+    "street",
+    "buildingNumber",
+    "zip",
+    "area",
+}
 
 
 async def async_get_config_entry_diagnostics(
@@ -24,6 +40,7 @@ async def async_get_config_entry_diagnostics(
     diagnostics_data = {
         "account": async_redact_data(config_entry.data, TO_REDACT),
         "options": async_redact_data(config_entry.options, TO_REDACT),
+        "sites": async_redact_data(hass.data[DOMAIN]["diagnostics"], TO_REDACT_SITES),
     }
 
     return diagnostics_data


### PR DESCRIPTION
When Easee ready backplates are included in an installation, they will show up as chargers without a valid ID or name.
A check for this is added to the code.

Debug data with site information is also added to the diagnostics data download.