### PR TITLE
Change to native_value for sensors

### DIFF
--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -157,8 +157,8 @@ class ChargerEntity(Entity):
         )
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
+    def native_unit_of_measurement(self):
+        """Return the native unit of measurement of this entity, if any."""
         return self._units
 
     @property

--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -29,8 +29,8 @@ class ChargerSensor(ChargerEntity, SensorEntity):
     """Implementation of Easee charger sensor."""
 
     @property
-    def state(self):
-        """Return status."""
+    def native_value(self):
+        """Return native value of sensor."""
         return self._state
 
 
@@ -38,8 +38,8 @@ class EqualizerSensor(ChargerEntity, SensorEntity):
     """Implementation of Easee equalizer sensor."""
 
     @property
-    def state(self):
-        """Return status."""
+    def native_value(self):
+        """Return native value of sensor."""
         return self._state
 
     @property


### PR DESCRIPTION
Sensors should report `native_value` and `native_unit_of_measurement` instead of deprecated `state` and `unit_of_measurement`. This is to enable centralized conversion of values for presentation in the UI. Today (HA 2022.4) this feature is implemented for e.g. temperature, pressure and distance but so far not for power (W/kW) or energy (Wh/kWh).