### PR TITLE
Improve startup robustness

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,14 +1,6 @@
 {
   "name": "Easee EV Charger",
-  "domains": [
-    "binary_sensor",
-    "sensor",
-    "switch"
-  ],
   "homeassistant": "2022.5",
-  "iot_class": [
-    "Cloud Push"
-  ],
   "zip_release": true,
   "filename": "easee.zip"
 }


### PR DESCRIPTION
When the easee servers are malfunctioning, it seems that it is sometimes possible to login but not use the other API functions. This was badly handled in the code and this should improve that.
Also removes some deprecated data from hacs.json.