### PR TITLE
Remove unecessary polling of schedules.

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -401,6 +401,8 @@ class Controller:
     async def refresh_schedules(self, now=None):
         """Refreshes the charging schedules data"""
         for charger in self.chargers_data:
+            if charger.is_schedule_polled() and self.easee.sr_is_connected():
+                continue
             await charger.schedules_async_refresh()
 
         self.update_ha_state()


### PR DESCRIPTION
Currently the schedules are polled on a regular basis. This patch limits the polling to when the schedule is changed (as signalled by the signalr stream data).