### PR TITLE
Large site fixes

### DIFF
--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -58,7 +58,7 @@ class EaseeConfigFlow(config_entries.ConfigFlow):
                 easee = Easee(username, password, client_session)
                 # Check that login is possible
                 await easee.connect()
-                the_sites: List[Site] = await easee.get_sites()
+                the_sites: List[Site] = await easee.get_account_products()
                 self.sites = [site.name for site in the_sites]
 
                 if len(self.sites) == 1:

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -304,7 +304,7 @@ class Controller:
             return None
 
         try:
-            self.sites: List[Site] = await self.easee.get_sites()
+            self.sites: List[Site] = await self.easee.get_account_products()
             self.diagnostics["sites"] = self.sites
 
             self.monitored_sites = self.config.options.get(


### PR DESCRIPTION
Changed calls to get_sites to get_account_products since the latter returns only the sites/products that are accessible by the logged in user and therefore avoids a lot of non functioning entities in large installations (hopefully).