### PR TITLE
Always display currency symbol if set on site

### DIFF
--- a/custom_components/easee/sensor.py
+++ b/custom_components/easee/sensor.py
@@ -39,11 +39,17 @@ class ChargerSensor(ChargerEntity, SensorEntity):
         if self._state_key == "site.costPerKWh":
             return self.data.site.get("currencyId", "")
         elif self._state_key == "cost_day.totalCost":
-            return self.data.cost_day.get("currencyId", "")
+            if not (unit := self.data.cost_day.get("currencyId", "")):
+                unit = self.data.site.get("currencyId", "")
+            return unit
         elif self._state_key == "cost_month.totalCost":
-            return self.data.cost_month.get("currencyId", "")
+            if not (unit := self.data.cost_month.get("currencyId", "")):
+                unit = self.data.site.get("currencyId", "")
+            return unit
         elif self._state_key == "cost_year.totalCost":
-            return self.data.cost_year.get("currencyId", "")
+            if not (unit := self.data.cost_year.get("currencyId", "")):
+                unit = self.data.site.get("currencyId", "")
+            return unit
 
         return self._units
 


### PR DESCRIPTION
The cost sensors do not report a currency symbol if there is no charging session during the respective period.
This fix will add the currency symbol set up for the site if none is reported by API.
Before: 0
Now: 0.00 EUR