### PR TITLE
Improved handling of 400 and 403 responses

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -148,15 +148,18 @@ class ProductData:
             dt.as_utc(dt_start), dt.as_utc(dt_end)
         )
         _LOGGER.debug("Cost refreshed %s %s %s", costs_day, costs_month, costs_year)
-        for cost in costs_day:
-            if cost["chargerId"] == self.product.id:
-                self.cost_day = cost
-        for cost in costs_month:
-            if cost["chargerId"] == self.product.id:
-                self.cost_month = cost
-        for cost in costs_year:
-            if cost["chargerId"] == self.product.id:
-                self.cost_year = cost
+        if costs_day is not None:
+            for cost in costs_day:
+                if cost["chargerId"] == self.product.id:
+                    self.cost_day = cost
+        if costs_month is not None:
+            for cost in costs_month:
+                if cost["chargerId"] == self.product.id:
+                    self.cost_month = cost
+        if costs_year is not None:
+            for cost in costs_year:
+                if cost["chargerId"] == self.product.id:
+                    self.cost_year = cost
 
     def check_value(self, data_type, reference, value):
         if (

--- a/custom_components/easee/manifest.json
+++ b/custom_components/easee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/fondberg/easee_hass",
   "issue_tracker": "https://github.com/fondberg/easee_hass/issues",
   "requirements": [
-    "pyeasee==0.7.47rc1"
+    "pyeasee==0.7.48rc2"
   ],
   "config_flow": true,
   "codeowners": [

--- a/custom_components/easee/services.py
+++ b/custom_components/easee/services.py
@@ -7,6 +7,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util import dt
+from pyeasee.exceptions import BadRequestException, ForbiddenServiceException
 import voluptuous as vol
 
 from .const import DOMAIN
@@ -444,6 +445,20 @@ async def async_setup_services(hass):
                     return await function_call(enable)
                 else:
                     return await function_call()
+            except BadRequestException as ex:
+                msg = ex.args[0].get("title", "")
+                _LOGGER.error(
+                    "Bad request: %s - Bad parameters or command not allowed now | %s",
+                    str(call.service),
+                    msg,
+                )
+                return
+            except ForbiddenServiceException:
+                _LOGGER.error(
+                    "Forbidden service: %s - Check your access privileges",
+                    str(call.service),
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -474,6 +489,20 @@ async def async_setup_services(hass):
                     return await function_call(enable)
                 else:
                     return await function_call()
+            except BadRequestException as ex:
+                msg = ex.args[0].get("title", "")
+                _LOGGER.error(
+                    "Bad request: %s - Bad parameters or command not allowed now | %s",
+                    str(call.service),
+                    msg,
+                )
+                return
+            except ForbiddenServiceException:
+                _LOGGER.error(
+                    "Forbidden service: %s - Check your access privileges",
+                    str(call.service),
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",

--- a/custom_components/easee/services.py
+++ b/custom_components/easee/services.py
@@ -446,17 +446,17 @@ async def async_setup_services(hass):
                 else:
                     return await function_call()
             except BadRequestException as ex:
-                msg = ex.args[0].get("title", "")
                 _LOGGER.error(
-                    "Bad request: %s - Bad parameters or command not allowed now | %s",
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
                     str(call.service),
-                    msg,
+                    ex,
                 )
                 return
-            except ForbiddenServiceException:
+            except ForbiddenServiceException as ex:
                 _LOGGER.error(
-                    "Forbidden service: %s - Check your access privileges",
+                    "Forbidden : [%s] - Check your access privileges: %s",
                     str(call.service),
+                    ex,
                 )
                 return
             except Exception:
@@ -490,11 +490,11 @@ async def async_setup_services(hass):
                 else:
                     return await function_call()
             except BadRequestException as ex:
-                msg = ex.args[0].get("title", "")
+                # msg = ex.args[0].get("title", "")
                 _LOGGER.error(
-                    "Bad request: %s - Bad parameters or command not allowed now | %s",
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
                     str(call.service),
-                    msg,
+                    ex.message.get("title", ""),
                 )
                 return
             except ForbiddenServiceException:
@@ -534,6 +534,20 @@ async def async_setup_services(hass):
                     dt.as_utc(stop_datetime),
                     repeat,
                 )
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -569,6 +583,20 @@ async def async_setup_services(hass):
             function_call = getattr(circuit, function_name["function_call"])
             try:
                 return await function_call(currentP1, currentP2, currentP3)
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -614,6 +642,20 @@ async def async_setup_services(hass):
             function_call = getattr(charger, function_name["function_call"])
             try:
                 return await function_call(currentP1, currentP2, currentP3)
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -653,6 +695,20 @@ async def async_setup_services(hass):
             function_call = getattr(charger, function_name["function_call"])
             try:
                 return await function_call(current)
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -680,6 +736,20 @@ async def async_setup_services(hass):
             function_call = getattr(charger.site, function_name["function_call"])
             try:
                 return await function_call(cost_per_kwh, vat, currency)
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",
@@ -700,6 +770,20 @@ async def async_setup_services(hass):
             function_call = getattr(charger, function_name["function_call"])
             try:
                 return await function_call(access_level)
+            except BadRequestException as ex:
+                _LOGGER.error(
+                    "Bad request: [%s] - Invalid parameters or command not allowed now: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
+            except ForbiddenServiceException as ex:
+                _LOGGER.error(
+                    "Forbidden : [%s] - Check your access privileges: %s",
+                    str(call.service),
+                    ex,
+                )
+                return
             except Exception:
                 _LOGGER.error(
                     "Failed to execute service: %s with data %s",

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -3,7 +3,6 @@
 import logging
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.exceptions import HomeAssistantError
 from pyeasee.exceptions import ForbiddenServiceException
 
 from .const import DOMAIN

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -31,9 +31,8 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(True)
-        except ForbiddenServiceException as ex:
-            _LOGGER.error("%s - Forbidden service - Check your access rights", self._entity_name)
-            raise HomeAssistantError(f"Forbidden {self._entity_name} - No access right") from ex
+        except ForbiddenServiceException:
+            raise HomeAssistantError(f"Forbidden {self._entity_name} turn_on - No access right") from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
 
@@ -46,9 +45,8 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(False)
-        except ForbiddenServiceException as ex:
-            _LOGGER.debug("%s - Forbidden service - Check your access rights", self._entity_name)
-            raise HomeAssistantError(f"Forbidden {self._entity_name} - No access right") from ex
+        except ForbiddenServiceException:
+            raise HomeAssistantError(f"Forbidden {self._entity_name} turn_off - No access right") from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
 

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -25,9 +25,6 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on the switch."""
         _LOGGER.debug("%s Switch turn on" % self._entity_name)
-        self.set_value_from_key(self._state_key, True)
-        self._state = True
-        self.async_write_ha_state()
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(True)
@@ -35,13 +32,14 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
             raise HomeAssistantError(f"Forbidden {self._entity_name} turn_on - No access right") from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
+            return
+        self.set_value_from_key(self._state_key, True)
+        self._state = True
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the switch."""
         _LOGGER.debug("%s Switch turn off" % self._entity_name)
-        self.set_value_from_key(self._state_key, False)
-        self._state = False
-        self.async_write_ha_state()
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(False)
@@ -49,6 +47,10 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
             raise HomeAssistantError(f"Forbidden {self._entity_name} turn_off - No access right") from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
+            return
+        self.set_value_from_key(self._state_key, False)
+        self._state = False
+        self.async_write_ha_state()
 
     @property
     def is_on(self):

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -30,9 +30,8 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         try:
             await function_call(True)
         except ForbiddenServiceException:
-            raise HomeAssistantError(
-                f"Forbidden {self._entity_name} turn_on - No access right"
-            ) from None
+            _LOGGER.error("Forbidden turn_on on switch %s", self._entity_name)
+            return
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
             return
@@ -47,9 +46,8 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         try:
             await function_call(False)
         except ForbiddenServiceException:
-            raise HomeAssistantError(
-                f"Forbidden {self._entity_name} turn_off - No access right"
-            ) from None
+            _LOGGER.error("Forbidden turn_off on switch %s", self._entity_name)
+            return
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
             return

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -3,11 +3,12 @@
 import logging
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.exceptions import HomeAssistantError
+from pyeasee.exceptions import ForbiddenServiceException
 
 from .const import DOMAIN
 from .entity import ChargerEntity
-from pyeasee.exceptions import ForbiddenServiceException
-from homeassistant.exceptions import HomeAssistantError
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -29,7 +30,9 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         try:
             await function_call(True)
         except ForbiddenServiceException:
-            raise HomeAssistantError(f"Forbidden {self._entity_name} turn_on - No access right") from None
+            raise HomeAssistantError(
+                f"Forbidden {self._entity_name} turn_on - No access right"
+            ) from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
             return
@@ -44,7 +47,9 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         try:
             await function_call(False)
         except ForbiddenServiceException:
-            raise HomeAssistantError(f"Forbidden {self._entity_name} turn_off - No access right") from None
+            raise HomeAssistantError(
+                f"Forbidden {self._entity_name} turn_off - No access right"
+            ) from None
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
             return

--- a/custom_components/easee/switch.py
+++ b/custom_components/easee/switch.py
@@ -6,7 +6,8 @@ from homeassistant.components.switch import SwitchEntity
 
 from .const import DOMAIN
 from .entity import ChargerEntity
-
+from pyeasee.exceptions import ForbiddenServiceException
+from homeassistant.exceptions import HomeAssistantError
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -30,6 +31,9 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(True)
+        except ForbiddenServiceException as ex:
+            _LOGGER.error("%s - Forbidden service - Check your access rights", self._entity_name)
+            raise HomeAssistantError(f"Forbidden {self._entity_name} - No access right") from ex
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
 
@@ -42,6 +46,9 @@ class ChargerSwitch(ChargerEntity, SwitchEntity):
         function_call = getattr(self.data.product, self._switch_func)
         try:
             await function_call(False)
+        except ForbiddenServiceException as ex:
+            _LOGGER.debug("%s - Forbidden service - Check your access rights", self._entity_name)
+            raise HomeAssistantError(f"Forbidden {self._entity_name} - No access right") from ex
         except Exception:
             _LOGGER.error("Got server error while calling %s", self._switch_func)
 


### PR DESCRIPTION
Only `site_admin` or `site_owner` are allowed to toggle some switches. If the authenticated user is a `site_user` a 403-Forbidden is returned.
This PR tries to handle this situation. It requires an updated lib that can raise `ForbiddenServiceError` exceptions.