### PR TITLE
Remove option to change units kW/W kWh/Wh

### DIFF
--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -89,6 +89,17 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
         config_entry.version = 2
 
+    if config_entry.version == 2:
+
+        options = {**config_entry.options}
+        # modify Config Entry data
+        if "custom_units" in options:
+            options.pop("custom_units")
+
+        config_entry.options = {**options}
+
+        config_entry.version = 3
+
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 
     return True

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 class EaseeConfigFlow(config_entries.ConfigFlow):
     """Easee config flow."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     def __init__(self):

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.typing import ConfigType
 from pyeasee import AuthorizationFailedException, Easee, Site
 import voluptuous as vol
 
-from .const import CONF_MONITORED_SITES, CUSTOM_UNITS, CUSTOM_UNITS_OPTIONS, DOMAIN
+from .const import CONF_MONITORED_SITES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,10 +161,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_MONITORED_SITES, default_sites
                         ),
                     ): cv.multi_select(sites_multi_select),
-                    vol.Optional(
-                        CUSTOM_UNITS,
-                        default=self.config_entry.options.get(CUSTOM_UNITS, []),
-                    ): cv.multi_select(CUSTOM_UNITS_OPTIONS),
                 }
             ),
             errors=errors,

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -17,22 +17,11 @@ TIMEOUT = 30
 VERSION = "0.9.48"
 MIN_HA_VERSION = "2023.4.0"
 CONF_MONITORED_SITES = "monitored_sites"
-CUSTOM_UNITS = "custom_units"
 MANUFACTURER = "Easee"
 MODEL_EQUALIZER = "Equalizer"
 MODEL_CHARGING_ROBOT = "Charging Robot"
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 LISTENER_FN_CLOSE = "update_listener_close_fn"
-CUSTOM_UNITS_OPTIONS = {
-    UnitOfPower.KILO_WATT: f"Power {UnitOfPower.KILO_WATT} to {UnitOfPower.WATT}",
-    UnitOfEnergy.KILO_WATT_HOUR: (
-        f"Energy {UnitOfEnergy.KILO_WATT_HOUR} to {UnitOfEnergy.WATT_HOUR}"
-    ),
-}
-CUSTOM_UNITS_TABLE = {
-    UnitOfPower.KILO_WATT: UnitOfPower.WATT,
-    UnitOfEnergy.KILO_WATT_HOUR: UnitOfEnergy.WATT_HOUR,
-}
 
 chargerObservations = {
     ChargerStreamData.config_phaseMode.value,
@@ -145,10 +134,6 @@ MANDATORY_EASEE_ENTITIES = {
             "state.ledMode",
             "state.cableRating",
             "config.authorizationRequired",
-            "state.pairedUserIDToken",
-            "state.userIDToken",
-            "state.userIDTokenReversed",
-            "config.limitToSinglePhaseCharging",
             "config.localNodeType",
             "config.localAuthorizationRequired",
             "config.ledStripBrightness",
@@ -184,10 +169,7 @@ OPTIONAL_EASEE_ENTITIES = {
     "cable_locked": {
         "type": "binary_sensor",
         "key": "state.cableLocked",
-        "attrs": [
-            "state.lockCablePermanently",
-            "state.cableLocked",
-        ],
+        "attrs": [],
         "units": None,
         "convert_units_func": None,
         "translation_key": "cable_locked",
@@ -199,10 +181,7 @@ OPTIONAL_EASEE_ENTITIES = {
     "cable_locked_permanently": {
         "type": "switch",
         "key": "state.lockCablePermanently",
-        "attrs": [
-            "state.lockCablePermanently",
-            "state.cableLocked",
-        ],
+        "attrs": [],
         "units": None,
         "convert_units_func": None,
         "translation_key": "cable_locked_permanently",
@@ -703,8 +682,6 @@ EASEE_EQ_ENTITIES = {
     "import_power": {
         "key": "state.activePowerImport",
         "attrs": [
-            "state.activePowerImport",
-            "state.reactivePowerImport",
             "state.maxPowerImport",
         ],
         "units": UnitOfPower.KILO_WATT,
@@ -715,16 +692,35 @@ EASEE_EQ_ENTITIES = {
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": None,
     },
+    "import_reactive_power": {
+        "key": "state.reactivePowerImport",
+        "attrs": [],
+        "units": UnitOfPower.KILO_WATT,
+        "convert_units_func": None,
+        "suggested_display_precision": 1,
+        "translation_key": "import_reactive_power",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": None,
+    },
     "export_power": {
         "key": "state.activePowerExport",
-        "attrs": [
-            "state.activePowerExport",
-            "state.reactivePowerExport",
-        ],
+        "attrs": [],
         "units": UnitOfPower.KILO_WATT,
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "export_power",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": None,
+    },
+    "export_reactive_power": {
+        "key": "state.reactivePowerExport",
+        "attrs": [],
+        "units": UnitOfPower.KILO_WATT,
+        "convert_units_func": None,
+        "suggested_display_precision": 1,
+        "translation_key": "export_reactive_power",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": None,
@@ -785,10 +781,7 @@ EASEE_EQ_ENTITIES = {
     },
     "import_energy": {
         "key": "state.cumulativeActivePowerImport",
-        "attrs": [
-            "state.cumulativeActivePowerImport",
-            "state.cumulativeReactivePowerImport",
-        ],
+        "attrs": [],
         "units": UnitOfEnergy.KILO_WATT_HOUR,
         "convert_units_func": None,
         "suggested_display_precision": 1,
@@ -798,16 +791,37 @@ EASEE_EQ_ENTITIES = {
         "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
+    "import_reactive_energy": {
+        "key": "state.cumulativeReactivePowerImport",
+        "attrs": [],
+        "units": UnitOfEnergy.KILO_WATT_HOUR,
+        "convert_units_func": None,
+        "suggested_display_precision": 1,
+        "translation_key": "import_reactive_energy",
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "icon": None,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
     "export_energy": {
         "key": "state.cumulativeActivePowerExport",
-        "attrs": [
-            "state.cumulativeActivePowerExport",
-            "state.cumulativeReactivePowerExport",
-        ],
+        "attrs": [],
         "units": UnitOfEnergy.KILO_WATT_HOUR,
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "export_energy",
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "icon": None,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "export_reactive_energy": {
+        "key": "state.cumulativeReactivePowerExport",
+        "attrs": [],
+        "units": UnitOfEnergy.KILO_WATT_HOUR,
+        "convert_units_func": None,
+        "suggested_display_precision": 1,
+        "translation_key": "export_reactive_energy",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "icon": None,

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -699,7 +699,7 @@ EASEE_EQ_ENTITIES = {
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "import_reactive_power",
-        "device_class": SensorDeviceClass.POWER,
+        "device_class": SensorDeviceClass.POWER,  # Note, at the time of writing REACTIVE_POWER does not support kVAr, so we can not use it.
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": None,
     },
@@ -721,7 +721,7 @@ EASEE_EQ_ENTITIES = {
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "export_reactive_power",
-        "device_class": SensorDeviceClass.POWER,
+        "device_class": SensorDeviceClass.POWER,  # Note, at the time of writing REACTIVE_POWER does not support kVAr, so we can not use it.
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": None,
     },
@@ -798,7 +798,7 @@ EASEE_EQ_ENTITIES = {
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "import_reactive_energy",
-        "device_class": SensorDeviceClass.ENERGY,
+        "device_class": SensorDeviceClass.ENERGY,  # Note, at the time of writing there is no REACTIVE_ENERGY class.
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
@@ -822,7 +822,7 @@ EASEE_EQ_ENTITIES = {
         "convert_units_func": None,
         "suggested_display_precision": 1,
         "translation_key": "export_reactive_energy",
-        "device_class": SensorDeviceClass.ENERGY,
+        "device_class": SensorDeviceClass.ENERGY,  # Note, at the time of writing there is no REACTIVE_ENERGY class.
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -37,8 +37,6 @@ from pyeasee.exceptions import (
 from .binary_sensor import ChargerBinarySensor, EqualizerBinarySensor
 from .const import (
     CONF_MONITORED_SITES,
-    CUSTOM_UNITS,
-    CUSTOM_UNITS_TABLE,
     DOMAIN,
     EASEE_EQ_ENTITIES,
     MANDATORY_EASEE_ENTITIES,
@@ -686,10 +684,6 @@ class Controller:
         data,
     ):
 
-        custom_units = self.config.options.get(CUSTOM_UNITS, {})
-        if data["units"] in custom_units:
-            data["units"] = CUSTOM_UNITS_TABLE[data["units"]]
-
         entity_type_name = ENTITY_TYPES[object_type]
 
         entity = entity_type_name(
@@ -713,10 +707,11 @@ class Controller:
             entity_category=data.get("entity_category", None),
         )
         _LOGGER.debug(
-            "Adding entity: %s (%s) for product %s",
+            "Adding entity: %s (%s) for product %s, unit %s",
             name,
             object_type,
             product_data.product.name,
+            data["units"],
         )
         if object_type == "sensor":
             self.sensor_entities.append(entity)

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -157,7 +157,7 @@ class ChargerEntity(Entity):
 
     @property
     def extra_state_attributes(self):
-        """Return the state attributes."""
+        """Return the extra state attributes."""
         try:
             attrs = {
                 "name": self.data.product.name,

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -156,7 +156,7 @@ class ChargerEntity(Entity):
         return True
 
     @property
-    def state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         try:
             attrs = {

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -130,14 +130,26 @@
       "export_energy": {
         "name": "Export energy"
       },
+      "export_reactive_energy": {
+        "name": "Export reactive energy"
+      },
       "export_power": {
         "name": "Export power"
+      },
+      "export_reacitve_power": {
+        "name": "Export reactive power"
       },
       "import_energy": {
         "name": "Import energy"
       },
+      "import_reactive_energy": {
+        "name": "Import reactive energy"
+      },
       "import_power": {
         "name": "Import power"
+      },
+      "import_reactive_power": {
+        "name": "Import reactive power"
       },
       "internal_temperature": {
         "name": "Internal temperature"

--- a/custom_components/easee/translations/sv.json
+++ b/custom_components/easee/translations/sv.json
@@ -130,14 +130,26 @@
       "export_energy": {
         "name": "Exporterad energi"
       },
+      "export_reactive_energy": {
+        "name": "Exporterad reaktiv energi"
+      },
       "export_power": {
         "name": "Exporterad effekt"
+      },
+      "export_reactive_power": {
+        "name": "Exporterad reaktiv effekt"
       },
       "import_energy": {
         "name": "Importerad energi"
       },
+      "import_reactive_energy": {
+        "name": "Importerad reaktiv energi"
+      },
       "import_power": {
         "name": "Importerad effekt"
+      },
+      "import_reactive_power": {
+        "name": "Importerad reaktiv effekt"
       },
       "internal_temperature": {
         "name": "Intern temperatur"


### PR DESCRIPTION
HA UI can now natively adjust units and precision, so the ability to change this in the integrations configuration was removed.
To facilitate this, some equalizer sensor attributes has been changed in to separate sensors:
Export reactive energy
Import reactive energy
Export reactive power
Import reactive power