### PR TITLE
Entities return state as None instead of ""

### DIFF
--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -255,6 +255,8 @@ class ChargerEntity(Entity):
         )
         try:
             self._state = self.get_value_from_key(self._state_key)
+            if self._state == "":
+                self._state = None
             if self._state_func is not None:
                 if self._state_key.startswith("state"):
                     self._state = self._state_func(self.data.state)


### PR DESCRIPTION
The state of an entity should never be an empty string. This PR will replace empty strings in states with None