### PR TITLE
Improve error handling around latest firmware API endpoint

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -576,8 +576,11 @@ OPTIONAL_EASEE_ENTITIES = {
         "translation_key": "update_available",
         "device_class": None,
         "icon": "mdi:file-download",
-        "state_func": lambda state: int(state["chargerFirmware"])
-        < int(state["latestFirmware"]),
+        "state_func": lambda state: (
+            int(state["chargerFirmware"]) < int(state["latestFirmware"])
+        )
+        if state["latestFirmware"] is not None
+        else None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -98,6 +98,7 @@ class ProductData:
         self.event_loop = event_loop
         self.poll_observations = poll_observations
         self.master = master
+        self.firmware_auth_failure = None
 
     def is_state_polled(self):
         if self.state is None:
@@ -138,8 +139,10 @@ class ProductData:
 
         try:
             firmware = await self.product.get_latest_firmware()
-        except AuthorizationFailedException:
-            _LOGGER.debug("Failed to fetch latest firmware info")
+        except AuthorizationFailedException as ex:
+            if self.firmware_auth_failure is None:
+                _LOGGER.error("Authorization failure when fetching firmware info: %s", ex)
+                self.firmware_auth_failure = True
             self.state["latestFirmware"] = None
             return
 


### PR DESCRIPTION
Log error once when firmware api endpoint fails. Make upgrade sewnsor display Unknown when data is unavailable.
