### PR TITLE
provide fix for utc offset in energy consumption

### DIFF
--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -263,7 +263,13 @@ class ChargerEntity(Entity):
                 raise IndexError("Unknown first part of key")
 
             if isinstance(value, datetime):
+                if value.tzinfo is None:
+                    value = value.replace(tzinfo=dt_util.UTC)
+                # Convert to configured local time zone
                 value = dt_util.as_local(value)
+
+
+
         except KeyError:
             value = ""
 


### PR DESCRIPTION
The energy consumption is being recorded with an 1-hour offset for me, similar to the issue related here:
https://github.com/nordicopen/easee_hass/issues/151

this should fix it.