### PR TITLE
Fix reboot action command not visible in UI

### DIFF
--- a/custom_components/easee/services.yaml
+++ b/custom_components/easee/services.yaml
@@ -18,9 +18,10 @@ action_command:
           options:
             - start
             - stop
-            - toggle
             - pause
             - resume
+            - toggle
+            - reboot
             - update_firmware
             - override_schedule
             - delete_basic_charge_plan


### PR DESCRIPTION
Services.yaml was missing the reboot command in the action_command section.